### PR TITLE
Publish component model book

### DIFF
--- a/.github/workflows/component-model.yml
+++ b/.github/workflows/component-model.yml
@@ -1,0 +1,34 @@
+name: Publish Component Model book
+on:
+  push:
+    paths:
+      - component-model/**
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install mdbook
+        run: |
+          wget https://github.com/rust-lang/mdBook/releases/download/v0.4.34/mdbook-v0.4.34-x86_64-unknown-linux-gnu.tar.gz
+          tar xvf mdbook-v0.4.34-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Build book
+        run: ./mdbook build component-model
+
+      - name: Install Spin
+        uses: fermyon/actions/spin/setup@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish book
+        uses: fermyon/actions/spin/deploy@v1
+        with:
+          manifest_file: component-model/spin.toml
+          fermyon_token: ${{ secrets.FERMYON_CLOUD_TOKEN }}

--- a/component-model/.gitignore
+++ b/component-model/.gitignore
@@ -1,1 +1,2 @@
 book
+.spin

--- a/component-model/spin.toml
+++ b/component-model/spin.toml
@@ -1,0 +1,13 @@
+spin_manifest_version = "1"
+authors = ["itowlson <ivan.towlson@fermyon.com>"]
+description = "The WebAssembly Component Model mdbook"
+name = "wasm-component-model-book"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+[[component]]
+source = { url = "https://github.com/fermyon/spin-fileserver/releases/download/v0.0.3/spin_static_fs.wasm", digest = "sha256:38bf971900228222f7f6b2ccee5051f399adca58d71692cdfdea98997965fd0d" }
+id = "wasm-component-model-book"
+files = [{ source = "book", destination = "/" }]
+[component.trigger]
+route = "/..."


### PR DESCRIPTION
This would use Fermyon Cloud as the publishing platform - I'm not trying to force this on anyone it's just the one I know how to deploy to.

The publish workflow needs a Fermyon Cloud access token - I don't have permission to add secrets to the repo, so if this is accepted then someone else will need to create and add one.
