### PR TITLE
Deeper dive into exporting and importing interfaces in Rust

### DIFF
--- a/component-model/src/SUMMARY.md
+++ b/component-model/src/SUMMARY.md
@@ -5,6 +5,7 @@
   - [Concepts](./concepts.md)
   - [An Overview of WIT](./wit-overview.md)
 - [Language Support for Components](./language-support.md)
+  - [Rust](./language-support/rust.md)
 - [Creating and Consuming Components](./creating-and-consuming.md)
   - [Authoring Components](./creating-and-consuming/authoring.md)
   - [Composing Components](./creating-and-consuming/composing.md)

--- a/component-model/src/language-support/rust.md
+++ b/component-model/src/language-support/rust.md
@@ -18,7 +18,7 @@ See [the language guide](../language-support.md#building-a-component-with-cargo-
 
 ## Exporting an interface with `cargo component`
 
-The sample `add.wit` file exports a function. However, to use your component from another component, it must export an interface. This results in slightly fiddlier bindings. For example, to implement the following world:
+The [sample `add.wit` file](../../examples/add.wit) exports a function. However, to use your component from another component, it must export an interface. This results in slightly fiddlier bindings. For example, to implement the following world:
 
 ```
 package docs:sample
@@ -171,3 +171,86 @@ world root {
 ```
 
 As the import is unfulfilled, the `calculator.wasm` component could not run by itself in its current form. To fulfil the `add` import, so that the calculator can run, you would need to [compose the `calculator.wasm` and `adder.wasm` files into a single, self-contained component](../creating-and-consuming/composing.md).
+
+## Creating a command component with `cargo component`
+
+A _command_ is a component with a specific export that allows it to be executed directly by `wasmtime` (or other `wasm:cli` hosts). In Rust terms, it's the equivalent of an application (`bin`) package with a `main` function, instead of a library crate (`lib`) package.
+
+To create a command with cargo component, run:
+
+```sh
+cargo component new <name>
+```
+
+Unlike library components, this does _not_ have the `--reactor` flag. You will see that the created project is different too:
+
+* It doesn't contain a `.wit` file. `cargo component build` will automatically export the `wasm:cli/run` interface for Rust `bin` packages, and hook it up to `main`.
+* Because there's no `.wit` file, `Cargo.toml` doesn't contain a `package.metadata.component.target` section.
+* The Rust file is called `main.rs` instead of `lib.rs`, and contains a `main` function instead of an interface implementation.
+
+You can write Rust in this project, just as you normally would, including importing your own or third-party crates.
+
+> All the crates that make up your project are linked together at build time, and compiled to a _single_ Wasm component. In this case, all the linking is happening at the Rust level: no WITs or component composition is involved. Only if you import Wasm interfaces do WIT and composition come into play.
+
+To run your command component:
+
+```
+cargo component build
+wasmtime run --wasm-features component-model ./target/wasm32-wasi/debug/<name>.wasm
+```
+
+> **WARNING:** If your program prints to standard out or error, you may not see the printed output! Some versions of `wasmtime` have a bug where they don't flush output streams before exiting. To work around this, add a `std::thread::sleep()` with a 10 millisecond delay before exiting `main`.
+
+### Importing an interface into a command component
+
+As mentioned above, `cargo component build` doesn't generate a WIT file for a command component. If you want to import a Wasm interface, though, you'll need to create a WIT file and a world, plus reference the packages containing your imports:
+
+1. Add a `wit/world.wit` to your project, and write a WIT world that imports the interface(s) you want to use. For example:
+
+```
+package docs:app
+
+world app {
+    import docs:calculator/calculate@0.1.0
+}
+```
+
+> `cargo component` sometimes fails to find packages if versions are not set explicitly. For example, if the calculator WIT declares `package docs:calculator` rather than `docs:calculator@0.1.0`, then you may get an error even though `cargo component build` automatically versions the binary export.
+
+2. Edit `Cargo.toml` to tell `cargo component` about the new WIT file:
+
+```toml
+[package.metadata.component.target]
+path = "wit"
+```
+
+(This entry is created automatically for library components but not for command components.)
+
+3. Edit `Cargo.toml` to tell `cargo component` where to find external package WITs:
+
+[package.metadata.component.target.dependencies]
+"docs:calculator" = { path = "../calculator/wit" }
+"docs:adder" = { path = "../adder/wit" }
+
+> If the external package refers to other packages, you need to provide the paths to them as well.
+
+3. Use the imported interface in your Rust code:
+
+```rust
+use bindings::docs::calculator::calculate::eval_expression;
+
+fn main() {
+    let result = eval_expression("1 + 1");
+    println!("1 + 1 = {result}");
+    std::thread::sleep(Duration::from_millis(10));
+}
+```
+
+4. [Compose the command component with the `.wasm` components that implement the imports.](../creating-and-consuming/composing.md)
+
+5. Run the composed component:
+
+```
+$ wasmtime run --wasm-features component-model ./my-composed-command.wasm
+1 + 1 = 579  # might need to go back and do some work on the calculator implementation
+```

--- a/component-model/src/language-support/rust.md
+++ b/component-model/src/language-support/rust.md
@@ -1,0 +1,173 @@
+# Components in Rust
+
+Rust has first-class support for the component model via [the `cargo component` tool](https://github.com/bytecodealliance/cargo-component).
+
+## Installing `cargo component`
+
+To install `cargo component`, run:
+
+```
+cargo install --git https://github.com/bytecodealliance/cargo-component --locked cargo-component
+```
+
+> There is currently no binary or `crates.io` distribution of `cargo component`.
+
+## Creating a library component with `cargo component`
+
+See [the language guide](../language-support.md#building-a-component-with-cargo-component).
+
+## Exporting an interface with `cargo component`
+
+The sample `add.wit` file exports a function. However, to use your component from another component, it must export an interface. This results in slightly fiddlier bindings. For example, to implement the following world:
+
+```
+package docs:sample
+
+interface demo {
+    test: func(text: string) -> string
+}
+
+world sample {
+    export demo
+}
+```
+
+you would write the following Rust code:
+
+```rust
+cargo_component_bindings::generate!();
+
+// Separating out the interface puts it in a sub-module
+use bindings::exports::docs::sample::demo::Demo;
+
+struct Component;
+
+impl Demo for Component {
+    fn test(text: String) -> String {
+        todo!()
+    }
+}
+```
+
+## Export versioning
+
+When `cargo component build` exports an interface, it sets the version to the package version, as listed in `Cargo.toml`. For example, given the interface above, if `Cargo.toml` contains:
+
+```toml
+[package]
+name = "sample"
+version = "0.2.0"
+```
+
+then the interface is exported as `docs:sample@0.2.0`. This can be important when working with binary tools that care about interface versions.
+
+## Importing an interface with `cargo component`
+
+The world file (`wit/world.wit`) generated for you by `cargo component new --reactor` doesn't specify any imports.
+
+> `cargo component build`, by default, uses the Rust `wasm32-wasi` target, and therefore automatically imports any required WASI interfaces - no action is needed from you to import these. This section is about importing custom WIT interfaces from library components.
+
+If your component consumes other components, you can edit the `world.wit` file to import their interfaces.
+
+For example, suppose you have created and built an adder component:
+
+```
+// in the 'adder' project
+
+// wit/world.wit
+package docs:adder@0.1.0
+
+interface add {
+    add: func(a: u32, b: u32) -> u32
+}
+
+world adder {
+    export add
+}
+
+// src/lib.rs
+cargo_component_bindings::generate!();
+
+use bindings::exports::docs::adder::add::Add;
+
+struct Component;
+
+impl Add for Component {
+    fn add(a: u32, b: u32) -> u32 {
+        a + b
+    }
+}
+```
+
+and that you now want to use that component in a calculator component. Here is a partial example world for a calculator:
+
+```
+// in the 'calculator' project
+
+// wit/world.wit
+package docs:calculator
+
+interface calculate {
+    eval-expression: func(expr: string) -> u32
+}
+
+world calculator {
+    export calculate
+    import docs:adder/add@0.1.0
+}
+```
+
+### Referencing the package to import
+
+Because the `docs:adder` package is in a different project, we must first tell `cargo component` how to find it. To do this, add the following to the `Cargo.toml` file:
+
+```toml
+[package.metadata.component.target.dependencies]
+"docs:adder" = { path = "../adder/wit" }  # directory containing the WIT package
+```
+
+Note that the path is to the adder project's WIT _directory_, not to the `world.wit` file. A WIT package may be spread across multiple files in the same directory; `cargo component` will look at all the files.
+
+### Calling the import from Rust
+
+Now the declaration of `add` in the adder's WIT file is visible to the `calculator` project. To invoke the imported `add` interface from the `calculate` implementation:
+
+```rust
+// src/lib.rs
+cargo_component_bindings::generate!();
+
+use bindings::exports::docs::calculator::calculate::Calculate;
+
+// Bring the imported add function into scope
+use bindings::docs::adder::add::add;
+
+struct Component;
+
+impl Calculate for Component {
+    fn eval_expression(expr: String) -> u32 {
+        // Cleverly parse `expr` into values and operations, and evaluate
+        // them meticulously.
+        add(123, 456)
+    }
+}
+```
+
+### Fulfilling the import
+
+When you build this using `cargo component build`, the `add` interface remains imported. The calculator has taken a dependency on the `add` _interface_, but has not linked the `adder` implementation of that interface - this is not like referencing the `adder` crate. (Indeed, `calculator` could import the `add` interface even if there was no Rust project implementing the WIT file.) You can see this by running [`wasm-tools component wit`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component) to view the calculator's world:
+
+```
+# Do a release build to prune unused imports (e.g. WASI)
+$ cargo component build --release
+
+$ wasm-tools component wit ./target/wasm32-wasi/release/calculator.wasm
+package root:component
+
+world root {
+  import docs:adder/add@0.1.0
+
+  export docs:calculator/calculate@0.1.0
+}
+```
+
+As the import is unfulfilled, the `calculator.wasm` component could not run by itself in its current form. To fulfil the `add` import, so that the calculator can run, you would need to [compose the `calculator.wasm` and `adder.wasm` files into a single, self-contained component](../creating-and-consuming/composing.md).


### PR DESCRIPTION
@kate-goldenring while I was trying to get  `wasm-tools compose` to work, I ran into a few details about working with packages and interfaces that were outside the scope of the core language guide (well, I felt they would have overwhelmed it).  This proposes a separate page to go into that additional language-specific detail.  But if you'd prefer it to be on the language support page then  we can figure out how to structure that for sure!

(Note this has a reference to the compose page so we shouldn't merge it until that goes in... which reinforces my feeling that we should whack in what we have and then iterate...)