### PR TITLE
Link from repo to rendered version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains user-facing documentation for the WebAssembly component model.  "User-facing" means it focuses on how to use the component model, not on the internal design and implementation details.
 
+The documentation is published at <https://component-model.bytecodealliance.org/>.
+
 It is envisaged to contain two books, one on the component model itself, and one on WASI (WebAssembly System Interface). At the time of writing, the first book is in development, but the second is not yet started.
 
 Contributions are welcome - see [Contributing](./CONTRIBUTING.md) for more info. Planned work is listed in the Issues section, but if there's content missing that you think would be helpful to gain understanding of the component model, please feel free to add a new issue, or send a PR directly!


### PR DESCRIPTION
So it's easier to find the published site from the readme.