### PR TITLE
Add missing build command to tutorial readme

### DIFF
--- a/component-model/examples/tutorial/README.md
+++ b/component-model/examples/tutorial/README.md
@@ -38,6 +38,7 @@ To compose a calculator component with an add operator, run the following:
 ```sh
 (cd calculator && cargo component build --release)
 (cd adder && cargo component build --release)
+(cd command && cargo component build --release)
 wasm-tools compose calculator/target/wasm32-wasi/release/calculator.wasm -d adder/target/wasm32-wasi/release/adder.wasm -o composed.wasm
 wasm-tools compose command/target/wasm32-wasi/release/command.wasm -d composed.wasm -o command.wasm
 ```


### PR DESCRIPTION
If you follow the tutorial readme, the last command `wasm-tools compose command/target/wasm32-wasi/release/command.wasm -d composed.wasm -o command.wasm` will fail because command.wasm hasn't been built yet. This PR adds the missing command.