### PR TITLE
Update cargo component install doc

### DIFF
--- a/component-model/src/language-support/rust.md
+++ b/component-model/src/language-support/rust.md
@@ -7,11 +7,11 @@ creating WebAssembly components using Rust as the component's implementation lan
 
 To install `cargo component`, run:
 
-```
-cargo install --git https://github.com/bytecodealliance/cargo-component --locked cargo-component
+```sh
+cargo install cargo-component
 ```
 
-> There is currently no binary or `crates.io` distribution of `cargo component`.
+> You can find more details about `cargo component` in its [crates.io page](https://crates.io/crates/cargo-component).
 
 ## Building a Component with `cargo component`
 


### PR DESCRIPTION
The docs for installing the `cargo component` command was using the git repo and stating that there is not `crates.io` distribution of `cargo component`, which is no longer true (see [here](https://crates.io/crates/cargo-component)). This PR fixes that by documenting installing directly from `crates.io` and updating the info message.