### PR TITLE
Fix broken tutorial

### DIFF
--- a/component-model/examples/tutorial/command/src/main.rs
+++ b/component-model/examples/tutorial/command/src/main.rs
@@ -1,6 +1,6 @@
 cargo_component_bindings::generate!();
 use clap::Parser;
-use std::{fmt, thread::sleep};
+use std::{fmt};
 
 use bindings::docs::calculator::{calculate, calculate::Op};
 
@@ -37,8 +37,6 @@ impl Command {
     fn run(self) {
         let res = calculate::eval_expression(self.op, self.x, self.y);
         println!("{} {} {} = {res}", self.x, self.op, self.y);
-        // Sleep because bug
-        sleep(std::time::Duration::from_millis(10))
     }
 }
 


### PR DESCRIPTION
As described in #92, the tutorial was broken when using latest wasm-tools and wasmtime 15.0.1.

By removing the sleep instruction (which was there due to a bug that I can not reproduce) the tutorial works again as expected

Worth mentioning that composing the final `command.wasm` still produces a bunch of warnings. 

However, executing the resulting module with `wasmtime run` works again as expected

fixes #92 