### PR TITLE
Move the worlds section before the WIT section

### DIFF
--- a/component-model/src/SUMMARY.md
+++ b/component-model/src/SUMMARY.md
@@ -8,8 +8,8 @@
 - [Why the Component Model?](./design/why-component-model.md)
 - [Components](./design/components.md)
 - [Interfaces](./design/interfaces.md)
-- [WIT](./design/wit.md)
 - [Worlds](./design/worlds.md)
+- [WIT](./design/wit.md)
 - [Packages](./design/packages.md)
 - [Canonical ABI](./design/canonical-abi.md)
 


### PR DESCRIPTION
The WIT section is an in-depth examination of WIT and assumes knowledge of what WIT worlds are. This PR moves the section on worlds to before the section on WIT so that users are more likely to gain that knowledge before putting it to practice by writing WIT packages. 