### PR TITLE
Updated example-host to use the latest deps

### DIFF
--- a/component-model/examples/example-host/Cargo.toml
+++ b/component-model/examples/example-host/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "4.3.19", features = ["derive"] }
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "2ade3ad", features = ["component-model"] }
-wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "2ade3ad" }
-wasi-cap-std-sync = { git = "https://github.com/bytecodealliance/wasmtime", rev = "2ade3ad" }
+wasmtime = { version = "18", features = ["component-model"] }
+wasmtime-wasi = "18"
 anyhow = "1.0.72"

--- a/component-model/examples/example-host/src/add.rs
+++ b/component-model/examples/example-host/src/add.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use std::path::PathBuf;
 use wasmtime::component::*;
 use wasmtime::{Config, Engine, Store};
-use wasmtime_wasi::preview2::{command, Table, WasiCtx, WasiCtxBuilder, WasiView};
+use wasmtime_wasi::preview2::{command, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
 
 wasmtime::component::bindgen!({
     path: "add.wit",
@@ -34,13 +34,13 @@ pub async fn add(path: PathBuf, x: i32, y: i32) -> wasmtime::Result<i32> {
 }
 
 struct ServerWasiView {
-    table: Table,
+    table: ResourceTable,
     ctx: WasiCtx,
 }
 
 impl ServerWasiView {
     fn new() -> Self {
-        let table = Table::new();
+        let table = ResourceTable::new();
         let ctx = WasiCtxBuilder::new().inherit_stdio().build();
 
         Self { table, ctx }
@@ -48,19 +48,11 @@ impl ServerWasiView {
 }
 
 impl WasiView for ServerWasiView {
-    fn table(&self) -> &Table {
-        &self.table
-    }
-
-    fn table_mut(&mut self) -> &mut Table {
+    fn table(&mut self) -> &mut ResourceTable {
         &mut self.table
     }
 
-    fn ctx(&self) -> &WasiCtx {
-        &self.ctx
-    }
-
-    fn ctx_mut(&mut self) -> &mut WasiCtx {
+    fn ctx(&mut self) -> &mut WasiCtx {
         &mut self.ctx
     }
 }


### PR DESCRIPTION
`wasmtime_wasi::preview2::Table` was renamed to `ResourceTable` in version 17.0.