### PR TITLE
Rename `float32`/`float64` to `f32`/`f64`.

### DIFF
--- a/component-model/src/design/wit.md
+++ b/component-model/src/design/wit.md
@@ -97,7 +97,7 @@ WIT defines the following primitive types:
 | `char`                     | Unicode character. (Specifically, a [Unicode scalar value](https://unicode.org/glossary/#unicode_scalar_value).) |
 | `string`                   | A Unicode string - that is, a finite sequence of characters. |
 
-The `f32` and `f64` types support the usual set of IEEE 754 single and double-precision values, except that they logically only have a single NaN value. NaN payloads are not guaranteed to be preserved when values pass through WIT interfaces.
+The `f32` and `f64` types support the usual set of IEEE 754 single and double-precision values, except that they logically only have a single NaN value. The exact bit-level representation of a NaN is not guaranteed to be preserved when values pass through WIT interfaces.
 
 ### Lists
 

--- a/component-model/src/design/wit.md
+++ b/component-model/src/design/wit.md
@@ -93,9 +93,11 @@ WIT defines the following primitive types:
 | `bool`                     | Boolean value - true or false. |
 | `s8`, `s16`, `s32`, `s64`  | Signed integers of the appropriate width. For example, `s32` is a 32-bit integer. |
 | `u8`, `u16`, `u32`, `u64`  | Unsigned integers of the appropriate width. For example, `u32` is a 32-bit integer. |
-| `float32`, `float64`       | Floating-point numbers of the appropriate width. For example, `float64` is a 64-bit (double precision) floating-point number. |
+| `f32`, `f64`               | Floating-point numbers of the appropriate width. For example, `f64` is a 64-bit (double precision) floating-point number. See the note on NaNs below. |
 | `char`                     | Unicode character. (Specifically, a [Unicode scalar value](https://unicode.org/glossary/#unicode_scalar_value).) |
 | `string`                   | A Unicode string - that is, a finite sequence of characters. |
+
+The `f32` and `f64` types support the usual set of IEEE 754 single and double-precision values, except that they logically only have a single NaN value. NaN payloads are not guaranteed to be preserved when values pass through WIT interfaces.
 
 ### Lists
 


### PR DESCRIPTION
The `float32` and `float64` types are being
[renamed to `f32` and `f64`]. All the main tools have been updated to accept both old and new names for now, so there's no urgeny to change anything, but users who wish to can now start switching to the new `f32`/`f64` names.

While here, also add some brief documentation mentioning the handling of NaNs in `f32`/`f64`.

[renamed to `f32` and `f64`]: https://github.com/WebAssembly/component-model/issues/277