### PR TITLE
Fix typo in wasmtime.md

### DIFF
--- a/component-model/src/runtimes/wasmtime.md
+++ b/component-model/src/runtimes/wasmtime.md
@@ -1,6 +1,6 @@
 # Wasmtime
 
-[Wasmtime](https://github.com/bytecodealliance/wasmtime/) is the reference implementation of the Component Model. It supports running components that implement the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit) and serving components the implement the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit).
+[Wasmtime](https://github.com/bytecodealliance/wasmtime/) is the reference implementation of the Component Model. It supports running components that implement the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit) and serving components that implement the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit).
 
 ## Running command components with Wasmtime
 To run a command component with Wasmtime, execute:


### PR DESCRIPTION
Fix a simple typo in the docs.

Did not perform any further validation (since I'm only on the web editor, and it seems as safe as a change can be).