### PR TITLE
Added missing link to Go language support on home page

### DIFF
--- a/component-model/src/introduction.md
+++ b/component-model/src/introduction.md
@@ -7,7 +7,7 @@ The WebAssembly Component Model is a broad-reaching architecture for building in
 | [Why Components?]        | [Javascript]         | [Composing]       |
 | [Components]             | [Python]             | [Running]         |
 | [Interfaces]             | [Rust]               | [Distributing]    |
-| [Worlds]                 |                      |                   |
+| [Worlds]                 | [Go]                 |                   |
 
 [Why Components?]: ./design/why-component-model.md
 [Components]: ./design/components.md
@@ -17,6 +17,7 @@ The WebAssembly Component Model is a broad-reaching architecture for building in
 [Javascript]: ./language-support/javascript.md
 [Python]: ./language-support/python.md
 [Rust]: ./language-support/rust.md
+[Go]: ./language-support/go.md
 
 [Composing]: ./creating-and-consuming/composing.md
 [Running]: ./creating-and-consuming/running.md


### PR DESCRIPTION
The link for Go was missing:

<img width="1076" alt="image" src="https://github.com/bytecodealliance/component-docs/assets/22804520/a78f9af4-4ed4-463b-8521-ab9d9eb1e1bc">