### PR TITLE
.github/workflows/mdbook: bump python version to 3.13

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Build with mdBook
         run: mdbook build component-model
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.13'
       - name: Generate sitemap
         run: |
           cd component-model


### PR DESCRIPTION
I am using the demo from "basic usage" section of https://github.com/actions/setup-python/tree/v5/