### PR TITLE
feat: add page to hold additional references

### DIFF
--- a/component-model/src/SUMMARY.md
+++ b/component-model/src/SUMMARY.md
@@ -36,3 +36,7 @@
 # Advanced Topics
 
 - [Canonical ABI](./advanced/canonical-abi.md)
+
+# Reference
+
+- [Useful Links](./reference/useful-links.md)

--- a/component-model/src/reference/useful-links.md
+++ b/component-model/src/reference/useful-links.md
@@ -2,12 +2,12 @@
 
 The following references are helpful in understanding the Component Model and related ecosystem/projects.
 
-- [`WebAssembly/component-model` GitHub Repository][wasm-cm-repo]
-  - [Component Model AST Explainer][ast-explainer]
-  - [Canonical ABI Explainer][canonical-abi]
-- [WASI Preview 2][wasi-p2]
 - [WebAssembly Composition tool (`wac`)][wac]
 - [WebAssembly package tools (notably `wkg`)][wkg]
+- [WASI Preview 2][wasi-p2]
+- [Component Model internals][wasm-cm-repo]
+  - [Component Model AST][ast-explainer]
+  - [Canonical ABI][canonical-abi]
 
 [wasm-cm-repo]: https://github.com/WebAssembly/component-model
 [wasi-p2]: https://github.com/WebAssembly/WASI/tree/main/wasip2

--- a/component-model/src/reference/useful-links.md
+++ b/component-model/src/reference/useful-links.md
@@ -1,0 +1,17 @@
+# Useful links
+
+The following references are helpful in understanding the Component Model and related ecosystem/projects.
+
+- [`WebAssembly/component-model` GitHub Repository][wasm-cm-repo]
+  - [Component Model AST Explainer][ast-explainer]
+  - [Canonical ABI Explainer][canonical-abi]
+- [WASI Preview 2][wasi-p2]
+- [WebAssembly Composition tool (`wac`)][wac]
+- [WebAssembly package tools (notably `wkg`)][wkg]
+
+[wasm-cm-repo]: https://github.com/WebAssembly/component-model
+[wasi-p2]: https://github.com/WebAssembly/WASI/tree/main/wasip2
+[ast-explainer]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
+[canonical-abi]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md
+[wac]: https://github.com/bytecodealliance/wac
+[wkg]: https://github.com/bytecodealliance/wasm-pkg-tools


### PR DESCRIPTION
This PR adds a basic page for holding/accumulating additional references that help understand the component model

Resolves #12 