### PR TITLE
remove redundant wording from python.md

### DIFF
--- a/component-model/src/language-support/python.md
+++ b/component-model/src/language-support/python.md
@@ -100,7 +100,7 @@ Component built successfully
 Wasm components can also be invoked from Python applications. This walks through using tooling
 to call the [`app.wasm` component from the examples](../../examples/example-host/add.wasm).
 
-> `wasmtime-py` is only able to run components built with `componentize-py` when the `--stub-wasi` option is used at build time. This is because `wasmtime-py` does not yet support [resources](../design/wit.md#resources), which components built with `componentize-py` use by default by generating components which import most of the `wasi:cli` world.  See [this example](https://github.com/bytecodealliance/componentize-py/tree/main/examples/sandbox) of using the `--stub-wasi` option to generate a `wasmtime-py`-compatible component.
+> `wasmtime-py` is only able to run components built with `componentize-py` when the `--stub-wasi` option is used at build time. This is because `wasmtime-py` does not yet support [resources](../design/wit.md#resources), and `componentize-py` by default generates components which use resources from the `wasi:cli` world.  See [this example](https://github.com/bytecodealliance/componentize-py/tree/main/examples/sandbox) of using the `--stub-wasi` option to generate a `wasmtime-py`-compatible component.
 
 First, install [Python 3.11 or later](https://www.python.org/) and [pip](https://pypi.org/project/pip/) if you don't already have them. Then, install [`wasmtime-py`](https://github.com/bytecodealliance/wasmtime-py):
 


### PR DESCRIPTION
This is a follow up to https://github.com/bytecodealliance/component-docs/pull/190, which included some redundant wording.