### PR TITLE
Fix Go example

### DIFF
--- a/component-model/src/language-support/go.md
+++ b/component-model/src/language-support/go.md
@@ -40,13 +40,6 @@ $ wkg wit build
 WIT package written to docs:adder@0.1.0.wasm
 ```
 
-The `docs:adder@0.1.0.wasm` file is a Wasm encoding of the WIT package. Next, we can generate the bindings for it:
-
-```console
-$ go get go.bytecodealliance.org/cmd/wit-bindgen-go
-$ go run go.bytecodealliance.org/cmd/wit-bindgen-go generate -o internal/ ./docs:adder@0.1.0.wasm
-```
-
 Now, create your Go project:
 
 ```console
@@ -54,7 +47,7 @@ $ mkdir add && cd add
 $ go mod init example.com
 ```
 
-Next, we can generate the bindings for the `add.wit` file:
+Next, we can generate the bindings for the Wasm component:
 
 ```console
 $ go get go.bytecodealliance.org/cmd/wit-bindgen-go

--- a/component-model/src/language-support/go.md
+++ b/component-model/src/language-support/go.md
@@ -97,11 +97,11 @@ The `adder.exports.go` file contains the exported functions that need to be impl
 package main
 
 import (
-	"example.com/internal/example/component/example"
+	"example.com/internal/docs/adder/adder"
 )
 
 func init() {
-	example.Exports.Add = func(x int32, y int32) int32 {
+	adder.Exports.Add = func(x int32, y int32) int32 {
 		return x + y
 	}
 }
@@ -120,7 +120,7 @@ We can build our component using TinyGo by specifying the wit-package to be `add
 Under the hood, TinyGo invokes `wasm-tools` to embed the WIT file to the module and componentize it.
 
 ```console
-$ tinygo build -target=wasip2 -o add.wasm --wit-package add.wit --wit-world adder main.go
+$ tinygo build -target=wasip2 -o add.wasm --wit-package docs:adder@0.1.0.wasm --wit-world adder main.go
 ```
 
 We now have an add component that satisfies our `adder` world, exporting the `add` function, which 


### PR DESCRIPTION
I made some changes to the Go example because I had issues running it in its current state:

1. Looks like the instructions for running `wit-bindgen-go` are duplicated (and the 1st one doesn't work because no project was created at the point)
2. Update `main.go` to match example values
3. Fix `--wit-package` argument to `tinygo`