### PR TITLE
Update artifact action maybe correctly this time

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -55,7 +55,7 @@ jobs:
           python3 ../scripts/generate_sitemap.py --domain "component-model.bytecodealliance.org" --higher-priority "design" --output-path book/sitemap.xml
           cd ..
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./component-model/book
 


### PR DESCRIPTION
Sorry Kate I misread the error message as "you're using v3 and must upgrade (to v4)" when it was actually saying "one of your things uses v3 internally so you must upgrade _that_ (as it turns out, to v3)."  Sorry for the churn.
