### PR TITLE
Fix c docs

### DIFF
--- a/component-model/examples/example-host/add.c
+++ b/component-model/examples/example-host/add.c
@@ -1,9 +1,0 @@
-#include "example.h"
-#include <stdio.h>
-
-int32_t exports_example_add(int32_t x, int32_t y)
-{
-    int32_t result = x + y;
-    printf("%d", result);
-    return result;
-}

--- a/component-model/examples/example-host/add.c
+++ b/component-model/examples/example-host/add.c
@@ -1,0 +1,9 @@
+#include "example.h"
+#include <stdio.h>
+
+int32_t exports_example_add(int32_t x, int32_t y)
+{
+    int32_t result = x + y;
+    printf("%d", result);
+    return result;
+}

--- a/component-model/examples/example-host/src/async_add.rs
+++ b/component-model/examples/example-host/src/async_add.rs
@@ -21,8 +21,10 @@ pub async fn add(path: PathBuf, x: i32, y: i32) -> wasmtime::Result<i32> {
     let wasi_view = States::new();
     let mut store = Store::new(&engine, wasi_view);
     // Construct linker for linking interfaces.
-    // For this simple adder component, no need to link additional interfaces.
-    let linker = Linker::new(&engine);
+    // For this simple adder component, no need to manually link additional interfaces.
+    let mut linker = Linker::new(&engine);
+    // Add wasi exports to linker to support io interfaces
+    wasmtime_wasi::add_to_linker_async(&mut linker)?;
     let instance = Example::instantiate_async(&mut store, &component, &linker)
         .await
         .context("Failed to instantiate the example world")?;

--- a/component-model/examples/example-host/src/sync_add.rs
+++ b/component-model/examples/example-host/src/sync_add.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 use std::path::PathBuf;
 use wasmtime::component::{bindgen, Component, Linker};
 use wasmtime::{Engine, Store};
+use wasmtime_wasi;
 
 bindgen!({
     path: "add.wit",
@@ -19,8 +20,10 @@ pub fn add(path: PathBuf, x: i32, y: i32) -> wasmtime::Result<i32> {
     let wasi_view = States::new();
     let mut store = Store::new(&engine, wasi_view);
     // Construct linker for linking interfaces.
-    // For this simple adder component, no need to link additional interfaces.
-    let linker = Linker::new(&engine);
+    // For this simple adder component, no need to manually link additional interfaces.
+    let mut linker = Linker::new(&engine);
+    // Add wasi exports to linker to support io interfaces
+    wasmtime_wasi::add_to_linker_sync(&mut linker).expect("Coould not add wasi to linker");
     let instance = Example::instantiate(&mut store, &component, &linker)
         .context("Failed to instantiate the example world")?;
     instance

--- a/component-model/examples/example-host/src/sync_add.rs
+++ b/component-model/examples/example-host/src/sync_add.rs
@@ -23,7 +23,7 @@ pub fn add(path: PathBuf, x: i32, y: i32) -> wasmtime::Result<i32> {
     // For this simple adder component, no need to manually link additional interfaces.
     let mut linker = Linker::new(&engine);
     // Add wasi exports to linker to support io interfaces
-    wasmtime_wasi::add_to_linker_sync(&mut linker).expect("Coould not add wasi to linker");
+    wasmtime_wasi::add_to_linker_sync(&mut linker).expect("Could not add wasi to linker");
     let instance = Example::instantiate(&mut store, &component, &linker)
         .context("Failed to instantiate the example world")?;
     instance


### PR DESCRIPTION
Fixes #194 

Fixed two problems with the C docs and example host:
1. wit-bindgen has changed the names of exported C functions since the docs were originally written
2. Code written against the P1 adapter in wasmtime now requires the host to explicitly add wasi to the linker, and the P1 adapter must be kept up to date with the wastime version in the `example-host` as wasmtime updates with wasi-0.2.X patch releases. 

Examples tested and working on Win11 and MacOS 14.3