### PR TITLE
C# example - don't confuse int/s32 with uint/u32

### DIFF
--- a/component-model/src/language-support/csharp.md
+++ b/component-model/src/language-support/csharp.md
@@ -72,7 +72,7 @@ with an `add` function:
 package example:component;
 
 world example {
-    export add: func(x: s32, y: s32) -> s32;
+    export add: func(x: u32, y: u32) -> u32;
 }
 ```
 
@@ -94,7 +94,7 @@ namespace ExampleWorld;
 
 public class ExampleWorldImpl : IOperations
 {
-    public static int Add(int x, int y)
+    public static uint Add(uint x, uint y)
     {
         return x + y;
     }
@@ -144,7 +144,7 @@ namespace ExampleWorld.wit.exports.example.component;
 
 public class AddImpl : IAdd
 {
-    public static int Add(int x, int y)
+    public static uint Add(uint x, uint y)
     {
         return x + y;
     }


### PR DESCRIPTION
The C# examples aren't consistent with converting s32 to int and u32 to uint, leading to a broken example.
For consistency and simplicity, I've gone ahead and changed all numbers to only use unsigned integers.