### PR TITLE
Update python.md

### DIFF
--- a/component-model/src/language-support/python.md
+++ b/component-model/src/language-support/python.md
@@ -138,7 +138,7 @@ from wasmtime import Store
 def main():
     store = Store()
     component = Root(store)
-    print("1 + 2 = ", component.add(store, 1, 2))
+    print("1 + 2 =", component.add(store, 1, 2))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Remove extra space in Python code that would make it print:
```
1 + 2 =  3
```
instead of:
```
1 + 2 = 3
```