### PR TITLE
fix: hack around mdbook-linkcheck warnings

### DIFF
--- a/component-model/src/language-support/c.md
+++ b/component-model/src/language-support/c.md
@@ -216,3 +216,6 @@ or any other host.
 
 See the [Rust Tooling guide](../language-support/rust.md#running-a-component-from-rust-applications) for instructions on how to run this component from
 the Rust `example-host` (replacing the path to `add.wasm` with your `add-component` above).
+
+[!NOTE]: #
+[!WARNING]: #

--- a/component-model/src/language-support/csharp.md
+++ b/component-model/src/language-support/csharp.md
@@ -152,6 +152,7 @@ This kind of error normally indicates that the host in question does not contain
 
 [host]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/example-host
 [add-to-linker]: https://docs.wasmtime.dev/api/wasmtime_wasi/fn.add_to_linker_sync.html
+[example-host]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/example-host
 
 ## Building a component that exports an interface
 
@@ -325,3 +326,6 @@ wasmtime run ./dist/main.wasm
 Check out the [componentize-dotnet docs][componentize-dotnet-docs] for more configurations options.
 
 [componentize-dotnet-docs]: https://github.com/bytecodealliance/componentize-dotnet
+
+[!NOTE]: #
+[!WARNING]: #

--- a/component-model/src/language-support/go.md
+++ b/component-model/src/language-support/go.md
@@ -321,3 +321,6 @@ cargo run --release -- 1 2 /path/to/add.wasm
 ```
 
 [example-host]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/example-host
+
+[!NOTE]: #
+[!WARNING]: #

--- a/component-model/src/language-support/javascript.md
+++ b/component-model/src/language-support/javascript.md
@@ -548,3 +548,7 @@ reverseAndUppercase('!dlroW olleH') = HELLO WORLD!
 
 [wac]: https://github.com/bytecodealliance/wac
 [jco-examples-string-reverse-upper]: https://github.com/bytecodealliance/jco/tree/main/examples/components/string-reverse-upper
+
+[!TIP]: #
+[!NOTE]: #
+[!WARNING]: #

--- a/component-model/src/language-support/python.md
+++ b/component-model/src/language-support/python.md
@@ -154,3 +154,5 @@ $ python3 host.py
 [add-wasm]: https://github.com/bytecodealliance/component-docs/blob/main/component-model/examples/example-host/add.wasm
 
 [adder-wit]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/tutorial/wit/adder/world.wit
+
+[!NOTE]: #


### PR DESCRIPTION
This commit introduces a hack that suppresses mdbook-linkcheck warnings for link-like alert constructs like `[!NOTE]`, until an upstream fix can be merged.