### PR TITLE
Add documentation warnings for Rust, Go, and JavaScript

### DIFF
--- a/component-model/src/language-support/go.md
+++ b/component-model/src/language-support/go.md
@@ -286,6 +286,8 @@ Under the hood, TinyGo invokes `wasm-tools` to embed the WIT file to the module 
 tinygo build -target=wasip2 -o add.wasm --wit-package docs:adder@0.1.0.wasm --wit-world adder main.go
 ```
 
+> **WARNING:** By default, tinygo includes all debug-related information in your .wasm file. That is desirable when prototyping or testing locally to obtain useful backtraces in case of errors (for example, with `wasmtime::WasmBacktraceDetails::Enable`). To remove debug data and optimize your binary file, build with `-no-debug`. The resulting .wasm file will be considerably smaller (up to 75% reduction in size).
+
 We now have an add component that satisfies our `adder` world, exporting the `add` function, which
 
 We can confirm using the `wasm-tools component wit` command:

--- a/component-model/src/language-support/javascript.md
+++ b/component-model/src/language-support/javascript.md
@@ -106,6 +106,8 @@ You should see output like the following:
 OK Successfully written add.wasm.
 ```
 
+> **WARNING:** By using `--disable all`, your component won't get access to any WASI interfaces that might be useful for debugging or logging. For example, you can't `console.log(...)` or `console.error(...)` without `stdio`; you can't use `Math.random()` without `random`; and you can't use `Date.now()` or `new Date()` without `clocks`. Please note that calls to `Math.random()` or `Data.now()` will return seemengly valid outputs, but without actual randomness or timestamp correctness.
+
 [mdn-js-module]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
 
 ## Running the Component in the `example-host`

--- a/component-model/src/language-support/rust.md
+++ b/component-model/src/language-support/rust.md
@@ -90,6 +90,8 @@ Now, use `cargo component` to build the component, being sure to optimize with a
 cargo component build --release
 ```
 
+> **WARNING:** Building with `--release` removes all debug-related information from the resulting .wasm file. When prototyping or testing locally, you might want to avoid `--release` to obtain useful backtraces in case of errors (for example, with `wasmtime::WasmBacktraceDetails::Enable`). Note: the resulting .wasm file will be considerably larger (likely 4MB+).
+
 You can use `wasm-tools component wit` to output the WIT package of the component:
 
 ```


### PR DESCRIPTION
3 main changes:

1. Add a `--release` warning in the Rust docs to clarify that always building with `--release` might not be ideal if you're prototyping/testing locally and you need debug info in your backtraces
2. Add a `-no-debug` warning in the Go docs to clarify that by default tinygo includes all debug information and that you can optimize your .wasm file by using `-no-debug` (up to 75% reduction in size)
3. Add a `--disable all` warning in the JS docs since many users might actually need to use `console.log` or `new Date()` in their component for logging/debugging