### PR TITLE
Match variable names to arguments

### DIFF
--- a/component-model/examples/tutorial/adder/src/lib.rs
+++ b/component-model/examples/tutorial/adder/src/lib.rs
@@ -7,7 +7,7 @@ struct Component;
 
 impl Guest for Component {
     fn add(x: u32, y: u32) -> u32 {
-        a + b
+        x + y
     }
 }
 

--- a/component-model/src/language-support/rust.md
+++ b/component-model/src/language-support/rust.md
@@ -148,7 +148,7 @@ struct Component;
 
 impl Guest for Component {
     fn add(x: u32, y: u32) -> u32 {
-        a + b
+        x + y
     }
 }
 ```


### PR DESCRIPTION
Small fix for code in examples and documentation to match variable names used in arguments.