### PR TITLE
chore(infra): Add `.gitattributes` file to repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Ensure all text is checked out with Unix EOL
+* text=auto eol=lf
+
+# Ensure binary files aren't considered as text
+*.wasm binary
+
+# Genrated code from cargo-component
+component-model/examples/tutorial/*/src/bindings.rs linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 
 # Genrated code from cargo-component
 component-model/examples/tutorial/*/src/bindings.rs linguist-generated
+
+Cargo-component.lock linguist-language=toml
+


### PR DESCRIPTION
Added a `.gitattributes` file to help [github-linguist understand](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md) what files are binaries or generated code.