### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This file is described here:  https://help.github.com/en/articles/about-code-owners
+
+# Global Owners: These members are Maintainers of the docs
+* @itowlson
+* @kate-goldenring
+* @vados-cosmonic


### PR DESCRIPTION
Adds codeowners to ensure maintainers are tagged on PRs. Also, adds @vados-cosmonic as another maintainer of the docs.