### PR TITLE
remove 6.1 'Authoring Components' section

### DIFF
--- a/component-model/src/SUMMARY.md
+++ b/component-model/src/SUMMARY.md
@@ -23,7 +23,6 @@
   - [Python](./language-support/python.md)
   - [Rust](./language-support/rust.md)
 - [Creating and Consuming Components](./creating-and-consuming.md)
-  - [Authoring Components](./creating-and-consuming/authoring.md)
   - [Composing Components](./creating-and-consuming/composing.md)
   - [Running Components](./creating-and-consuming/running.md)
   - [Distributing and Fetching Components and WIT](./creating-and-consuming/distributing.md)

--- a/component-model/src/creating-and-consuming/authoring.md
+++ b/component-model/src/creating-and-consuming/authoring.md
@@ -1,5 +1,0 @@
-# Authoring Components
-
-You can write WebAssembly core modules in a wide variety of languages, and the set of languages that can directly create components is growing. See the [Language Support](../language-support.md) section for information on building components directly from source code.
-
-If your preferred language supports WebAssembly but not components, you can still create components using the [`wasm-tools component`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component) tool.  (A future version of this page will cover this in more detail.)

--- a/component-model/src/tutorial.md
+++ b/component-model/src/tutorial.md
@@ -79,8 +79,7 @@ These files define:
 
 ## Create an `add` component
 
-Reference the [language guide](language-support.md) and [authoring components
-documentation](creating-and-consuming/authoring.md) to create a component that implements the
+Reference the [language guide](language-support.md) to create a component that implements the
 `adder` world of `adder/wit/world.wit`.
 
 For reference, see the completed
@@ -88,8 +87,7 @@ For reference, see the completed
 
 ## Create a `calculator` component
 
-Reference the [language guide](language-support.md) and [authoring components
-documentation](creating-and-consuming/authoring.md) to create a component that implements the
+Reference the [language guide](language-support.md) to create a component that implements the
 `calculator` world of `wit/calculator/world.wit`.
 
 For reference, see the completed


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/component-docs/issues/263.  For context, in the SIG Docs call, there was discussion around reorganizing chapter 6.  One of the take aways was that this section does not add much information to the chapter as a whole.