### PR TITLE
Revise and reorganize "Why the Component Model?" section

### DIFF
--- a/component-model/src/design/why-component-model.md
+++ b/component-model/src/design/why-component-model.md
@@ -31,7 +31,8 @@ A core module is a set of definitions.
 Kinds of definitions include:
 * _Functions_ define executable units of code
   (sequences of instructions along with declarations
-  for argument names and types and return types).
+  for the names of arguments
+  and the types of arguments and return values).
 * [_Linear memories_](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-mem)
   define buffers of uninterpreted bytes that can be read from
   and written to by instructions.
@@ -199,7 +200,7 @@ and thus it cannot indirectly communicate to others
 by writing to its memory and having others read from that memory.
 This not only reinforces sandboxing, but enables interoperation
 between languages that make different assumptions about memory:
-for example, allowing a component that relies garbage-collected memory
+for example, allowing a component that relies on garbage-collected memory
 to interoperate with one that uses conventional linear memory.
 
 ## Using components


### PR DESCRIPTION
I've tried to revise this section with a Wasm beginner in mind, as well as breaking it up into sections so it's a little easier to skim.

In some cases it was hard to be sure how much detail to go into vs. linking to external sources (e.g. memory), but I tried to strike a balance between not intimidating the reader with too much detail, and not intimidating the reader with undefined terms.

The diffs are a bit hard to follow, so it's probably easiest to review by viewing the rendered Markdown side-by-side with the current version.