### PR TITLE
Remove wasm-tools warning for Golang

### DIFF
--- a/component-model/src/language-support/go.md
+++ b/component-model/src/language-support/go.md
@@ -13,12 +13,6 @@ Follow the [TinyGo installation instructions](https://tinygo.org/getting-started
 
 Additionally, install the `wasm-tools` CLI tool from the [wasm-tools repository](https://github.com/bytecodealliance/wasm-tools/releases).
 
-> [!WARNING]
-> Due to some upstream issues, only `wasm-tools` versions 1.225.0 or earlier can be used with `wit-bindgen-go`
->
-> If using the Rust toolchain to install `wasm-tools`, it can be installed like so:
-> `cargo install --locked wasm-tools@1.225.0 --force`
-
 To verify the installation, run the following commands:
 
 ```

--- a/component-model/src/language-support/go.md
+++ b/component-model/src/language-support/go.md
@@ -13,6 +13,16 @@ Follow the [TinyGo installation instructions](https://tinygo.org/getting-started
 
 Additionally, install the `wasm-tools` CLI tool from the [wasm-tools repository](https://github.com/bytecodealliance/wasm-tools/releases).
 
+> [!WARNING]
+> `wit-bindgen-go` comes with its own `wasm-tools` vendored version, but tinygo still requires you to install it.
+> Even if unlikely, this could lead to version mismatch when using older versions of `wasm-tools`.
+> Please make sure to keep your local `wasm-tools` udpated, should you encounter any issues.
+>
+> If using the Rust toolchain to install `wasm-tools`, it can be installed like so:
+> `cargo install --locked wasm-tools@1.235.0 --force`
+> or via cargo binstall:
+> `cargo binstall wasm-tools@1.235.0`
+
 To verify the installation, run the following commands:
 
 ```


### PR DESCRIPTION
This has been fixed in https://github.com/bytecodealliance/go-modules/pull/298

Also see the discussion in https://github.com/bytecodealliance/go-modules/issues/297

I've re-tested today and it's working fine with the latest too (`wasm-tools@1.235.0`) 👌 