### PR TITLE
Replace instant with datetime in wit-example.md

### DIFF
--- a/component-model/src/design/wit-example.md
+++ b/component-model/src/design/wit-example.md
@@ -79,13 +79,13 @@ an unsigned 32-bit integer.
 The following declares a function named `now`:
 
 ```wit
-now: func() -> instant;
+now: func() -> datetime;
 ```
 
 The empty parentheses `()` indicate that the function has no arguments.
 The return type is the type after the final arrow (`->`),
-which is `instant`.
-Putting it together: `now()` is a nullary function that returns an instant.
+which is `datetime`.
+Putting it together: `now()` is a nullary function that returns a datetime.
 
 ### Summing up
 


### PR DESCRIPTION
I would imagine what happened here is that what is currently defined as datetime used to be called instant. It looks like it got renamed in some places, but not everywhere.

This patch tries to take care of that.

Apologies if I'm messing something up, this is my first pull request ever in this project.