### PR TITLE
"Running Components" section: minor style changes

### DIFF
--- a/component-model/src/running-components.md
+++ b/component-model/src/running-components.md
@@ -1,3 +1,7 @@
 # Running Components
 
-There are two standard wit worlds that runtimes support. These worlds are the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit) and the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit). All other wit worlds and interfaces are considered to be custom.  In the following sections, you'll see how to run components that implement either world, as well as how to invoke custom exports.
+There are two standard WIT worlds that runtimes support.
+These worlds are the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit)
+and the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit).
+All other WIT worlds and interfaces are considered to be custom.
+In the following sections, you'll see how to run components that implement either world, as well as how to invoke custom exports.

--- a/component-model/src/running-components/jco.md
+++ b/component-model/src/running-components/jco.md
@@ -1,6 +1,9 @@
 # jco
 
-[jco](https://github.com/bytecodealliance/jco) is a fully native JavaScript tool for working with components in JavaScript. It supports the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit). `jco` also provides features for transpiling Wasm components to ES modules, and for building Wasm components from JavaScript and WIT.
+[jco](https://github.com/bytecodealliance/jco) is a fully native JavaScript tool for working with components in JavaScript.
+It supports the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit).
+`jco` also provides features for transpiling WebAssembly components to ECMAScript modules (ES modules),
+and for building WebAssembly components from JavaScript and WIT.
 
 To run a component with `jco`, run:
 
@@ -8,4 +11,6 @@ To run a component with `jco`, run:
 jco run <path-to-wasm-file> <command-args...>
 ```
 
-`jco`'s WASI implementation grants the component full access to the underlying system resources. For example, the component can read all environment variables of the `jco` process, or read and write files anywhere in the file system.
+`jco`'s WASI implementation grants the component full access to the underlying system resources.
+For example, the component can read all environment variables of the `jco` process,
+or read and write files anywhere in the file system.

--- a/component-model/src/running-components/wasmtime.md
+++ b/component-model/src/running-components/wasmtime.md
@@ -1,6 +1,9 @@
 # Wasmtime
 
-[Wasmtime](https://github.com/bytecodealliance/wasmtime/) is the reference implementation of the Component Model. It supports running components that implement the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit) and serving components that implement the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit). Wasmtime can also invoke functions exported from a component.
+[Wasmtime](https://github.com/bytecodealliance/wasmtime/) is the reference implementation of the Component Model.
+It supports running components that implement the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit)
+and serving components that implement the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit).
+Wasmtime can also invoke functions exported from a component.
 
 ## Running command components with Wasmtime
 To run a command component with Wasmtime, execute:
@@ -9,13 +12,17 @@ To run a command component with Wasmtime, execute:
 wasmtime run <path-to-wasm-file>
 ```
 
-> If you are using an older version of `wasmtime`, you may need to add the `--wasm component-model` flag to specify that you are running a component rather than a core module.
+> If you are using an older version of `wasmtime`, you may need to add the `--wasm component-model` flag
+> to specify that you are running a component rather than a core module.
 
-By default, Wasmtime denies the component access to all system resources. For example, the component cannot access the file system or environment variables. See the [Wasmtime guide](https://docs.wasmtime.dev/) for information on granting access, and for other Wasmtime features.
+By default, Wasmtime denies the component access to all system resources.
+For example, the component cannot access the file system or environment variables.
+See the [Wasmtime guide](https://docs.wasmtime.dev/) for information on granting access, and for other Wasmtime features.
 
 ## Running HTTP components with Wasmtime
 
-You can now execute components that implement the [HTTP proxy world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit) with the `wasmtime serve` subcommand. [The Wasmtime CLI](https://github.com/bytecodealliance/wasmtime) supports serving these components as of `v14.0.3`. 
+You can execute components that implement the [HTTP proxy world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit) with the `wasmtime serve` subcommand.
+[The Wasmtime CLI](https://github.com/bytecodealliance/wasmtime) supports serving these components as of `v14.0.3`.
 
 To run a HTTP component with Wasmtime, execute:
 ```sh
@@ -29,6 +36,7 @@ Try out building and running HTTP components with one of these tutorials
 2. [HTTP Auth Middleware tutorial](https://github.com/fermyon/http-auth-middleware#running-with-wasmtime) - compose a HTTP authentication middleware component with a business logic component
 
 ## Running components with custom exports
+
 As of Wasmtime Version 33.0.0, there is [support for invoking components with custom exports](https://bytecodealliance.org/articles/invoking-component-functions-in-wasmtime-cli).
 
 
@@ -37,4 +45,7 @@ As an example, if your component exports a function `add` which takes two numeri
 ```sh
 wasmtime run --invoke 'add(1, 2)' <path-to-wasm-file>
 ```
-Make sure to wrap your invocation in single quotes and to include parentheses, even if your function doesn't take any arguments. For a full list of ways to represent the various wit types when passing arguments to your exported function, visit the [WAVE repo](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-wave).
+
+Make sure to wrap your invocation in single quotes and to include parentheses, even if your function doesn't take any arguments.
+For a full list of ways to represent the various WIT types when passing arguments to your exported function,
+visit the [WAVE repository](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-wave).


### PR DESCRIPTION
For example, changing "wit" to "WIT" and "Wasm" to "WebAssembly".