### PR TITLE
Emscripten does not support the component model

### DIFF
--- a/component-model/src/language-support/c.md
+++ b/component-model/src/language-support/c.md
@@ -52,12 +52,6 @@ A WASI SDK installation will include a local version of `clang` configured with 
 for a particular target platform.)
 Follow [these instructions](https://github.com/WebAssembly/wasi-sdk#use) to configure WASI SDK for use.
 
-> [!NOTE]
-> You can also use your installed system or [Emscripten](https://emscripten.org/) `clang`
-> by building with `--target=wasm32-wasi`, but you will need some artifacts from WASI SDK
-> to enable and link that build target (see the text about `libclang_rt.*.a` objects in
-> [the WASI SDK README](https://github.com/webassembly/wasi-sdk?tab=readme-ov-file#about-this-repository)).
-
 ## 2. Generate program skeleton from WIT
 
 Start by pasting the contents of the [sample `adder/world.wit` file][sample-wit]


### PR DESCRIPTION
@tschneidereit wrote on the [BA Zulip](https://bytecodealliance.zulipchat.com/#narrow/channel/206238-general/topic/Emscripten.20Component.20Model.20Support/near/542487871) 

> Emscripten only supports wasip1
  