### PR TITLE
chore: remove references to wasmbuilder.app

### DIFF
--- a/component-model/src/composing-and-distributing/composing.md
+++ b/component-model/src/composing-and-distributing/composing.md
@@ -132,26 +132,3 @@ See the [`wac` documentation](https://github.com/bytecodealliance/wac) for more 
 For an in-depth description about how to use the `wac` tool,
 you can check out the [WAC language index](https://github.com/bytecodealliance/wac/blob/main/LANGUAGE.md)
 and [examples](https://github.com/bytecodealliance/wac/tree/main/examples).
-
-## Composing components with a visual interface
-
-You can compose components visually using the builder app at [wasmbuilder.app](https://wasmbuilder.app/).
-
-1. Use the "Add Component" button to upload the `.wasm` component files you want to compose.
-   The components appear in the sidebar.
-
-2. Drag the components onto the canvas.
-   You'll see imports listed on the left of each component, and exports on the right.
-
-3. Click the box in the top left to choose the 'primary' component, that is,
-   the one whose exports will be preserved.
-   (The clickable area is quite small—wait for the cursor to change from a hand to a pointer.)
-
-4. To fulfil one of the primary component's imports with a dependency's export,
-   drag from the "I" icon next to the export to the "I" item next to the import.
-   (Again, the clickable area is quite small—wait for the cursor to change from a hand to a cross.)
-
-5. When you have connected all the imports and exports that you want,
-   click the Download Component button to download the composed component as a `.wasm` file.
-
-[!NOTE]: #

--- a/component-model/src/tutorial.md
+++ b/component-model/src/tutorial.md
@@ -181,8 +181,6 @@ wac plug calculator.wasm --plug adder.wasm -o composed.wasm
 wac plug command.wasm --plug composed.wasm -o final.wasm
 ```
 
-> If you'd prefer to take a more visual approach to composing components, see the [documentation on composing components with wasmbuilder.app](composing-and-distributing/composing.md#composing-components-with-a-visual-interface).
-
 ## Running the calculator
 
 Now it all adds up! Run the final component with the `wasmtime` CLI, ensuring you are using a


### PR DESCRIPTION
This commit removes the references to wasmbuilder.app which seems to be down now and is not officially maintained by the BA (and is archived).

Resolves #323 