### PR TITLE
Update rust.md

### DIFF
--- a/component-model/src/language-support/building-a-simple-component/rust.md
+++ b/component-model/src/language-support/building-a-simple-component/rust.md
@@ -242,7 +242,7 @@ With the [`component-docs` repository][repo-component-docs] cloned locally, run 
 
 ```console
 $ cd examples/example-host
-$ cargo run --release -- 1 2 ../add/target/wasm32-wasip1/release/adder.wasm
+$ cargo run --release -- 1 2 ../add/target/wasm32-wasip2/release/adder.wasm
 1 + 2 = 3
 ```
 


### PR DESCRIPTION
Update code line to point to wasm32-wasip2 instead of wasm32-wasip1 that is not used here