### PR TITLE
Fix link to WASI 0.2.0 WIT definitions

### DIFF
--- a/component-model/src/introduction.md
+++ b/component-model/src/introduction.md
@@ -82,7 +82,7 @@ A system or platform may expose some or all of the WASI APIs to components.
 
 The current stable release of WASI is [WASI 0.2.0](https://github.com/WebAssembly/WASI/pull/577),
 which was released on January 25, 2024.
-WASI 0.2.0 is [a stable set of WIT definitions](https://github.com/WebAssembly/WASI/tree/main/wasip2)
+WASI 0.2.0 is [a stable set of WIT definitions](https://github.com/WebAssembly/WASI/blob/main/docs/Preview2.md)
 that components can target.
 WASI proposals will continue to evolve and new ones will be introduced;
 however, users of the component model can now pin to any stable release >= `v0.2.0`.


### PR DESCRIPTION
Updated the link for WASI 0.2.0 WIT definitions to point to the correct documentation.

The `wasip2` folder has been deleted and its README.md moved to `proposals/README.md` in https://github.com/WebAssembly/WASI/pull/828.

`proposals/README.md` was then moved to `docs/Preview2.md` in https://github.com/WebAssembly/WASI/pull/831