### PR TITLE
Fix broken links reported as warnings by mdbook

### DIFF
--- a/component-model/src/creating-runnable-components.md
+++ b/component-model/src/creating-runnable-components.md
@@ -27,7 +27,7 @@ wasmtime run --invoke 'add(1, 2)' add.component.wasm
 Wasmtime contains code that can generically interpret exports, convert arguments to WebAssembly arguments, and execute
 an existing component dynamically.
 
-[example-host](https://github.com/bytecodealliance/component-docs/blob/main/component-model/examples/example-host/README.md)
+[example-host]: https://github.com/bytecodealliance/component-docs/blob/main/component-model/examples/example-host/
 
 ## Creating components that behave like binaries
 
@@ -38,7 +38,7 @@ At a high level there are at least two ways to create components that are more l
 (i.e. that are easy to run from a tool like `wasmtime run`):
 
 1. Creating a "command" component
-2. Exporting the [`wasi:cli/run` interface][wasi-cli-run]
+2. Exporting the [`wasi:cli/run` interface][wasi-cli-iface-run]
 
 While command components simply have a `_start` export, components that export the [`wasi:cli/run` run interface][wasi-cli-iface-run]
 are able to make use of more robust standardized interfaces that mimic a CLI environment like stdout, stderr, via WASI.

--- a/component-model/src/language-support/building-a-simple-component/javascript.md
+++ b/component-model/src/language-support/building-a-simple-component/javascript.md
@@ -292,6 +292,7 @@ With `jco transpile`, any WebAssembly binary (compiled from any language) can be
 [jco-example]: https://github.com/bytecodealliance/jco/tree/main/examples/components/adder
 [wasm-core-module]: https://webassembly.github.io/spec/core/binary/modules.html
 [core-wasm]: https://webassembly.github.io/spec/core/
+[ts-decl-file]: https://www.typescriptlang.org/docs/handbook/declaration-files/deep-dive.html#declaration-file-theory-a-deep-dive
 
 [!TIP]: #
 [!NOTE]: #

--- a/component-model/src/language-support/importing-and-reusing-components/javascript.md
+++ b/component-model/src/language-support/importing-and-reusing-components/javascript.md
@@ -308,7 +308,6 @@ With the help of `jco`, we have:
 
 [docs-wit]: ../../design/wit.md
 [jco-examples-string-reverse]: https://github.com/bytecodealliance/jco/tree/main/examples/components/string-reverse
-[repo]: https://github.com/bytecodealliance/component-docs
 [string-reverse-package-json]: https://github.com/bytecodealliance/jco/blob/main/examples/components/string-reverse/package.json#L6
 [ts-decl-file]: https://www.typescriptlang.org/docs/handbook/declaration-files/deep-dive.html#declaration-file-theory-a-deep-dive
 [wasi]: https://wasi.dev/

--- a/component-model/src/language-support/importing-and-reusing-components/javascript.md
+++ b/component-model/src/language-support/importing-and-reusing-components/javascript.md
@@ -306,7 +306,13 @@ With the help of `jco`, we have:
 - Converted the compiled WebAssembly module (which could be from *any* language) to a module that can be used from any compliant JS runtime (`jco transpile`)
 - Run the transpiled WebAssembly component from a JavaScript native runtime (NodeJS)
 
-[repo]: https://github.com/bytecodealliance/component-docs
+[docs-wit]: ../../design/wit.md
 [jco-examples-string-reverse]: https://github.com/bytecodealliance/jco/tree/main/examples/components/string-reverse
-[ts-decl-file]: https://www.typescriptlang.org/docs/handbook/declaration-files/deep-dive.html#declaration-file-theory-a-deep-dive
+[repo]: https://github.com/bytecodealliance/component-docs
 [string-reverse-package-json]: https://github.com/bytecodealliance/jco/blob/main/examples/components/string-reverse/package.json#L6
+[ts-decl-file]: https://www.typescriptlang.org/docs/handbook/declaration-files/deep-dive.html#declaration-file-theory-a-deep-dive
+[wasi]: https://wasi.dev/
+
+[!NOTE]: #
+[!TIP]: #
+[!WARNING]: #

--- a/component-model/src/language-support/using-http-in-components/rust.md
+++ b/component-model/src/language-support/using-http-in-components/rust.md
@@ -121,3 +121,6 @@ Explore more examples of projects that use `wstd`:
 - [An example `wasi:http` server component](https://github.com/bytecodealliance/sample-wasi-http-rust)
 - [Various examples of using wstd](https://github.com/bytecodealliance/wstd/tree/main/examples)
 - [Examples of using wstd with Axum](https://github.com/bytecodealliance/wstd/tree/main/axum/examples)
+
+
+[!NOTE]: #


### PR DESCRIPTION
The PR aims at fixing the broken links  reported as warnings by `mdbook serve`.

I changed the link to the `example-host` repo to `https://github.com/bytecodealliance/component-docs/blob/main/component-model/examples/example-host/` instead of its `README.md` file. I think it makes it clearer that this is a independent repo.