### PR TITLE
replace deprecated wasi URLs into the current ones.

### DIFF
--- a/component-model/src/creating-runnable-components.md
+++ b/component-model/src/creating-runnable-components.md
@@ -45,7 +45,7 @@ are able to make use of more robust standardized interfaces that mimic a CLI env
 
 This section explores how to create components that are trivially runanbel (like binaries) in relevant languages.
 
-[wasi-cli-iface-run]: https://github.com/WebAssembly/wasi-cli/tree/main/wit/run.wit
+[wasi-cli-iface-run]: https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/run.wit
 
 ## Languages
 

--- a/component-model/src/design/component-model-concepts.md
+++ b/component-model/src/design/component-model-concepts.md
@@ -61,7 +61,7 @@ must be invoked in an environment that implements those interfaces.
  A [_package_](./packages.md) is a set of WIT files
 containing a related set of interfaces and worlds.
  
-For example, the [wasi-http](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit) package includes
+For example, the [wasi-http](https://github.com/WebAssembly/WASI/blob/main/proposals/http/wit/proxy.wit) package includes
 an `imports` world encapsulating the interfaces that an HTTP proxy depends on,
 and a `proxy` world that depends on `imports`.
 
@@ -102,9 +102,9 @@ standardizing the functionality components depend on.
 [design-choices]: https://github.com/WebAssembly/component-model/blob/main/design/high-level/Choices.md
 [wit]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 [wasi]: https://wasi.dev/
-[wasi-cli]: https://github.com/WebAssembly/wasi-cli/
-[wasi-cli-stdio]: https://github.com/WebAssembly/wasi-cli/blob/main/wit/stdio.wit
-[wasi-cli-command]: https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit
-[wasi-http]: https://github.com/WebAssembly/wasi-http
+[wasi-cli]: https://github.com/WebAssembly/WASI/tree/main/proposals/cli
+[wasi-cli-stdio]: https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/stdio.wit
+[wasi-cli-command]: https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/command.wit
+[wasi-http]: https://github.com/WebAssembly/WASI/tree/main/proposals/http
 
 [!NOTE]: #

--- a/component-model/src/design/interfaces.md
+++ b/component-model/src/design/interfaces.md
@@ -52,7 +52,7 @@ and imports anything imported by the "wall clock" interface.
 Interfaces are defined using [the WIT language](./wit.md).
 
 [wp-contract]: https://en.wikipedia.org/wiki/Design_by_contract
-[wasi-http-handler]: https://github.com/WebAssembly/wasi-http/blob/main/wit/handler.wit
-[wasi-clocks-wall-clock]: https://github.com/WebAssembly/wasi-clocks/blob/main/wit/wall-clock.wit
+[wasi-http-handler]: https://github.com/WebAssembly/WASI/blob/main/proposals/http/wit/handler.wit
+[wasi-clocks-wall-clock]: https://github.com/WebAssembly/WASI/blob/main/proposals/clocks/wit/wall-clock.wit
 
 > For a more formal definition of an interface, take a look at the [WIT specification](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md).

--- a/component-model/src/design/wit-example.md
+++ b/component-model/src/design/wit-example.md
@@ -7,7 +7,7 @@ For a full WIT reference, see [the next section](./wit.md).
 ## Clocks
 
 The following is a simplified version of the world defined in
-the [wasi:clocks](https://github.com/WebAssembly/wasi-clocks) package.
+the [wasi:clocks](https://github.com/WebAssembly/WASI/tree/main/proposals/clocks) package.
 
 Suppose we want to write a component that provides clock functionality.
 This component will represent a "wall clock", which can be reset
@@ -102,7 +102,7 @@ That was just a warm-up; let's look at an example that uses
 more of WIT's built-in and user-defined types.
 
 The following is a very simplified version of the main interface
-defined in the [wasi-filesystem](https://github.com/WebAssembly/wasi-filesystem) package.
+defined in the [wasi-filesystem](https://github.com/WebAssembly/WASI/tree/main/proposals/filesystem) package.
 Much of the functionality has been removed.
 Here, a file descriptor supports just two operations:
 * `open-at()`: Open a file.

--- a/component-model/src/language-support/building-a-simple-component/go.md
+++ b/component-model/src/language-support/building-a-simple-component/go.md
@@ -93,7 +93,7 @@ $ wkg wit build
 WIT package written to docs:adder@0.1.0.wasm
 ```
 
-[wasi-cli]: https://github.com/WebAssembly/wasi-cli
+[wasi-cli]: https://github.com/WebAssembly/WASI/tree/main/proposals/cli
 
 ## 3. Generate bindings for the Wasm component
 

--- a/component-model/src/language-support/creating-runnable-components/rust.md
+++ b/component-model/src/language-support/creating-runnable-components/rust.md
@@ -70,8 +70,8 @@ command line interface.
 Unlike command components, library components have no `_start`, but by exporting the `wasi:cli/run` interface,
 tooling that recognizes these exports can easily execute a given WebAssembly binary (e.g. `wasmtime run`).
 
-[wasi-cli-iface-run]: https://github.com/WebAssembly/wasi-cli/tree/main/wit/run.wit
-[wasi-cli]: https://github.com/WebAssembly/wasi-cli
+[wasi-cli-iface-run]: https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/run.wit
+[wasi-cli]: https://github.com/WebAssembly/WASI/tree/main/proposals/cli
 
 ### 1. Create a new Rust library project
 

--- a/component-model/src/reference/faq.md
+++ b/component-model/src/reference/faq.md
@@ -75,7 +75,7 @@ With WIT, platform builders can define *any* interface that WebAssembly componen
 expect to access—WASI enables building interfaces on top of a shared standard set of abstractions.
 
 [wit]: https://component-model.bytecodealliance.org/design/wit.html
-[wasi-http]: https://github.com/WebAssembly/wasi-http
+[wasi-http]: https://github.com/WebAssembly/WASI/tree/main/proposals/http
 
 ## Q: I see the terms Preview 1 and Preview 2 frequently. What do those refer to?
 
@@ -116,7 +116,7 @@ for interacting with environment variables.
 The component is said to "import" the `wasi:cli/environment` interface,
 using the available functions and types therein.
 
-[wasi-cli-env]: https://github.com/WebAssembly/wasi-cli/blob/main/wit/environment.wit
+[wasi-cli-env]: https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/environment.wit
 
 ## Q: What are component exports?
 

--- a/component-model/src/running-components.md
+++ b/component-model/src/running-components.md
@@ -1,7 +1,7 @@
 # Running Components
 
 There are two standard WIT worlds that runtimes support.
-These worlds are the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit)
-and the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit).
+These worlds are the [`wasi:cli/command` world](https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/command.wit)
+and the [`wasi:http/proxy` world](https://github.com/WebAssembly/WASI/blob/main/proposals/http/wit/proxy.wit).
 All other WIT worlds and interfaces are considered to be custom.
 In the following sections, you'll see how to run components that implement either world, as well as how to invoke custom exports.

--- a/component-model/src/running-components/jco.md
+++ b/component-model/src/running-components/jco.md
@@ -1,7 +1,7 @@
 # jco
 
 [jco](https://github.com/bytecodealliance/jco) is a fully native JavaScript tool for working with components in JavaScript.
-It supports the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit).
+It supports the [`wasi:cli/command` world](https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/command.wit).
 `jco` also provides features for transpiling WebAssembly components to ECMAScript modules (ES modules),
 and for building WebAssembly components from JavaScript and WIT.
 

--- a/component-model/src/running-components/wasmtime.md
+++ b/component-model/src/running-components/wasmtime.md
@@ -1,8 +1,8 @@
 # Wasmtime
 
 [Wasmtime](https://github.com/bytecodealliance/wasmtime/) is the reference implementation of the Component Model.
-It supports running components that implement the [`wasi:cli/command` world](https://github.com/WebAssembly/wasi-cli/blob/main/wit/command.wit)
-and serving components that implement the [`wasi:http/proxy` world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit).
+It supports running components that implement the [`wasi:cli/command` world](https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/command.wit)
+and serving components that implement the [`wasi:http/proxy` world](https://github.com/WebAssembly/WASI/blob/main/proposals/http/wit/proxy.wit).
 Wasmtime can also invoke functions exported from a component.
 
 ## Running command components with Wasmtime
@@ -21,7 +21,7 @@ See the [Wasmtime guide](https://docs.wasmtime.dev/) for information on granting
 
 ## Running HTTP components with Wasmtime
 
-You can execute components that implement the [HTTP proxy world](https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit) with the `wasmtime serve` subcommand.
+You can execute components that implement the [HTTP proxy world](https://github.com/WebAssembly/WASI/blob/main/proposals/http/wit/proxy.wit) with the `wasmtime serve` subcommand.
 [The Wasmtime CLI](https://github.com/bytecodealliance/wasmtime) supports serving these components as of `v14.0.3`.
 
 To run a HTTP component with Wasmtime, execute:

--- a/component-model/src/tutorial.md
+++ b/component-model/src/tutorial.md
@@ -101,7 +101,7 @@ A _command_ is a component with a specific export that allows it to be executed 
 `wasmtime` (or other `wasi:cli` hosts).
 
 The WebAssembly host expects it to export the [`wasi:cli/run`
-interface](https://github.com/WebAssembly/wasi-cli/blob/main/wit/run.wit), which is the equivalent
+interface](https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/run.wit), which is the equivalent
 of the [`main` function][wiki-entrypoint] to WASI.
 
 To build a command component, [`cargo`][cargo] should be configured to build a `--lib` crate which


### PR DESCRIPTION
@kate-goldenring 

can you take a look at this PR when you have time?
the fix is really minor to replace the deprecated(archived) wasi URL links into new ones in the official doc.
