### PR TITLE
Add WASI P3 entries to the FAQ

### DIFF
--- a/component-model/src/SUMMARY.md
+++ b/component-model/src/SUMMARY.md
@@ -14,7 +14,7 @@
   - [Async, Streams, and Futures](./design/async.md)
 - [WIT By Example](./design/wit-example.md)
 - [WIT Reference](./design/wit.md)
-- [Migrating from WASI P2 to WASI P3](./design/migrating-to-p3.md)
+- [Migrating from WASI 0.2 to WASI 0.3](./design/migrating-to-p3.md)
 
 # Using WebAssembly Components
 

--- a/component-model/src/SUMMARY.md
+++ b/component-model/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Async, Streams, and Futures](./design/async.md)
 - [WIT By Example](./design/wit-example.md)
 - [WIT Reference](./design/wit.md)
+- [Migrating from WASI P2 to WASI P3](./design/migrating-to-p3.md)
 
 # Using WebAssembly Components
 

--- a/component-model/src/SUMMARY.md
+++ b/component-model/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [Interfaces](./design/interfaces.md)
   - [Worlds](./design/worlds.md)
   - [Packages](./design/packages.md)
+  - [Async, Streams, and Futures](./design/async.md)
 - [WIT By Example](./design/wit-example.md)
 - [WIT Reference](./design/wit.md)
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -55,7 +55,7 @@ Note that synchronous functions which return `future<T>`s *cannot* block; the ca
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 ```
 
-## How the primitives work in WASI 0.3
+## A look at async patterns in WASI 0.3
 
 ### Stream plus terminal future
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -9,9 +9,12 @@ These new types let interfaces express asynchronous operations that compose acro
 
 For migration mechanics (e.g., how a WASI 0.2 component maps onto these primitives) see [Migrating from WASI 0.2 to WASI 0.3](./migrating-to-p3.md). 
 
-For the a closer look at WASI 0.3 release, including a full per-interface diff, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev. 
+For a closer look at the WASI 0.3 release, including a full per-interface diff, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev. 
 
 This page focuses on the Component Model concepts themselves.
+
+> [!NOTE]
+> WASI 0.3 builds on WASI 0.2 rather than replacing it. Runtimes can host both versions side by side, and a 0.3 host can polyfill 0.2 imports at the boundary, so applications can migrate incrementally as toolchains and dependencies land 0.3 support.
 
 ## The async problem that WASI 0.3 solves
 
@@ -32,6 +35,7 @@ A WIT function declared `async` tells the runtime that the call may suspend befo
 ```diff
 - handle: func(request: request) -> result<response, error-code>;
 + handle: async func(request: request) -> result<response, error-code>;
+```
 
 Code generated from the WIT picks up each language's natural async idiom: `async fn` in Rust, a `Promise`-returning function in JavaScript, a coroutine in Python.
 
@@ -39,7 +43,7 @@ Code generated from the WIT picks up each language's natural async idiom: `async
 
 A typed, asynchronous channel for a sequence of `T` values. Crucially, `stream<T>` is a Canonical ABI *value*, not a resource (as opposed to WASI 0.2) -- it can be returned from a call, accepted as a parameter, and handed from one component to another without giving up ownership of the underlying buffer. 
 
-The same value can also be passed straight through a one or more components without those component(s) having to relay any wake-ups.
+The same value can also be passed straight through one or more intermediate components without those components having to relay any wake-ups.
 
 ```wit
 read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
@@ -49,7 +53,7 @@ read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 
 A typed handle for a single value that will become available later. Like `stream<T>`, `future<T>` is a value rather than a resource, so it crosses component boundaries the same way a primitive does. 
 
-Note that synchronous functions which return `future<T>`s *cannot* block; the caller can awaits the result when it needs it.
+Note that synchronous functions which return `future<T>`s *cannot* block; the caller can await the result when it needs it.
 
 ```wit
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
@@ -59,7 +63,7 @@ write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 
 ### Stream plus terminal future
 
-Reads return both a data channel and a completion handle, packed into a tuple:
+Reads return both a data channel and a completion handle, packed into a tuple ([`read-via-stream`](https://github.com/WebAssembly/wasi-filesystem/blob/main/wit/types.wit#L308) in `wasi-filesystem`):
 
 ```wit
 read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
@@ -69,7 +73,7 @@ The two halves are independent. The caller can consume the stream eagerly, sampl
 
 ### Stream parameter, future return
 
-Writes use the symmetric shape: the guest supplies the data as a `stream<u8>` parameter, and the host returns a `future` that resolves once it has consumed the stream. Stdout, stderr, filesystem writes, and TCP sends all follow this shape:
+Writes use the symmetric shape: the guest supplies the data as a `stream<u8>` parameter, and the host returns a `future` that resolves once it has consumed the stream. Stdout, stderr, filesystem writes, and TCP sends all follow this shape ([`write-via-stream`](https://github.com/WebAssembly/wasi-filesystem/blob/main/wit/types.wit#L320) in `wasi-filesystem`):
 
 ```wit
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -1,0 +1,87 @@
+# Async, Streams, and Futures
+
+WASI P3 is built on three new Canonical ABI primitives in the Component Model: `async func`, `stream<T>`, and `future<T>`. Together, they let interfaces express asynchronous operations that compose across component boundaries.
+
+## Why native async?
+
+WASI P2 modeled asynchronous I/O through the `wasi:io` package, which exposed three resources:
+
+- `pollable`: an opaque handle representing readiness
+- `input-stream`: a byte source
+- `output-stream`: a byte sink
+
+These work fine when a component talks directly to its host. They break down when components are composed. Consider a three-layer chain:
+
+```
+A → B → Host
+```
+
+Component A makes a call into Component B that requires waiting on the Host. B calls the Host, which returns a `pollable` representing the eventual completion of the work. That `pollable` is a Component Model resource scoped to B's instance — A cannot hold it, poll it, or name it. B would have to actively check the `pollable` and forward the wake-up to A, but there is no Canonical ABI hook for "when this `pollable` becomes ready, run this code in B." In practice the wake-up gets dropped, and B has to actively poll its own `pollable` just to relay readiness back to A.
+
+This is sometimes called the **sandwich problem**: WASI P2 could express async, but could not compose it across component boundaries.
+
+The Component Model solves this by pushing async down into the Canonical ABI. The runtime owns scheduling and wake-up propagation, so async works correctly regardless of how many components sit between a producer and a consumer.
+
+## The three primitives
+
+### `async func`
+
+A function declared as asynchronous in WIT:
+
+```wit
+handle: async func(request: request) -> result<response, error-code>;
+```
+
+Bindings generators emit language-native async constructs: `async fn` in Rust, `Promise` in JavaScript, coroutines in Python.
+
+### `stream<T>`
+
+A typed, asynchronous data channel. Unlike `input-stream` and `output-stream` in WASI P2, a `stream<T>` is a *value* that can be passed across component boundaries the same way a `u32` can.
+
+```wit
+read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
+```
+
+### `future<T>`
+
+A single-value async completion. Where WASI P2 used `pollable` resources, WASI P3 uses `future<T>` values.
+
+```wit
+write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
+```
+
+## Common patterns
+
+### The stream-plus-future pattern
+
+A recurring pattern in WASI P3 pairs a `stream<T>` with a `future` that signals completion or error:
+
+```wit
+read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
+```
+
+The stream delivers data incrementally. Once the stream closes, the future resolves to indicate whether the operation completed successfully or encountered an error. This pattern appears in stdin, filesystem reads, TCP receives, and directory listings.
+
+### The write-direction flip
+
+In WASI P2, write operations gave you an `output-stream` that you wrote into. In WASI P3, the direction is reversed: you pass in a `stream<u8>` and receive a `future<result>` that resolves when the write completes. This applies to stdout, stderr, filesystem writes, and TCP sends.
+
+```wit
+// WASI P2: get a stream, write to it
+get-stdout: func() -> output-stream;
+
+// WASI P3: pass data in, get a completion future
+write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
+```
+
+## Tooling support
+
+`async func`, `stream<T>`, and `future<T>` are native Canonical ABI features in the Component Model, supported by:
+
+- [Wasmtime](https://wasmtime.dev/) 43 and later, via `-Sp3 -W component-model-async=y` when running components.
+- [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) with the `async` feature enabled, for Rust guest bindings.
+- [jco](https://github.com/bytecodealliance/jco) for JavaScript environments, via the `preview3-shim` package.
+
+For an end-to-end Rust example, see [Creating Runnable Components in Rust](../language-support/creating-runnable-components/rust.md). For the WIT-level details of how to declare these types in your own interfaces, see [WIT Reference](./wit.md).
+
+> For a broader overview of what changed in WASI P3, including per-interface diffs, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -7,7 +7,11 @@ WASI 0.3 adds new Canonical ABI primitives to the Component Model that enable as
 
 These new types let interfaces express asynchronous operations that compose across component boundaries.
 
-For migration mechanics (e.g., how a WASI 0.2 component maps onto these primitives) see [Migrating from WASI 0.2 to WASI 0.3](./migrating-to-p3.md). For the WASI release view, including the full per-interface diff, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev. This page focuses on the Component Model concepts themselves.
+For migration mechanics (e.g., how a WASI 0.2 component maps onto these primitives) see [Migrating from WASI 0.2 to WASI 0.3](./migrating-to-p3.md). 
+
+For the a closer look at WASI 0.3 release, including a full per-interface diff, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev. 
+
+This page focuses on the Component Model concepts themselves.
 
 ## Native async
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -47,7 +47,9 @@ read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 
 ### Futures (`future<T>`)
 
-A typed handle for a single value that will become available later. Like `stream<T>`, `future<T>` is a value rather than a resource, so it crosses component boundaries the same way a primitive does. A function returning `future<T>` does not block; the caller awaits the result when it needs it.
+A typed handle for a single value that will become available later. Like `stream<T>`, `future<T>` is a value rather than a resource, so it crosses component boundaries the same way a primitive does. 
+
+Note that synchronous functions which return `future<T>`s *cannot* block; the caller can awaits the result when it needs it.
 
 ```wit
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -29,9 +29,9 @@ Components can pass futures and streams along without keeping their own event lo
 
 A WIT function declared `async` tells the runtime that the call may suspend before producing its result. The Canonical ABI handles the suspension and resumption; the guest doesn't see a `pollable`, and the host doesn't see a polling loop.
 
-```wit
-handle: async func(request: request) -> result<response, error-code>;
-```
+```diff
+- handle: func(request: request) -> result<response, error-code>;
++ handle: async func(request: request) -> result<response, error-code>;
 
 Code generated from the WIT picks up each language's natural async idiom: `async fn` in Rust, a `Promise`-returning function in JavaScript, a coroutine in Python.
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -13,7 +13,7 @@ For the a closer look at WASI 0.3 release, including a full per-interface diff, 
 
 This page focuses on the Component Model concepts themselves.
 
-## Native async
+## The async problem that WASI 0.3 solves
 
 The Component Model's Canonical ABI defines how typed values cross component boundaries. Until WASI 0.3, that vocabulary had no notion of suspension or asynchronous completion; every interface call returned synchronously, and asynchronous I/O was modeled with resources (`pollable` for readiness, `input-stream` and `output-stream` for byte channels) scoped to whichever component obtained them.
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -25,7 +25,7 @@ Components can pass futures and streams along without keeping their own event lo
 
 ## Async functions, Streams, and Futures
 
-### `async func`
+### Async Functions (`async func`)
 
 A WIT function declared `async` tells the runtime that the call may suspend before producing its result. The Canonical ABI handles the suspension and resumption; the guest doesn't see a `pollable`, and the host doesn't see a polling loop.
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -1,12 +1,12 @@
 # Async, Streams, and Futures
 
-WASI P3 is built on three new Canonical ABI primitives in the Component Model: `async func`, `stream<T>`, and `future<T>`. Together, they let interfaces express asynchronous operations that compose across component boundaries.
+WASI 0.3 is built on three new Canonical ABI primitives in the Component Model: `async func`, `stream<T>`, and `future<T>`. Together, they let interfaces express asynchronous operations that compose across component boundaries.
 
-For migration mechanics (e.g., how a WASI P2 component maps onto these primitives) see [Migrating from WASI P2 to WASI P3](./migrating-to-p3.md). For the WASI release view, including the full per-interface diff, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev. This page focuses on the Component Model concepts themselves.
+For migration mechanics (e.g., how a WASI 0.2 component maps onto these primitives) see [Migrating from WASI 0.2 to WASI 0.3](./migrating-to-p3.md). For the WASI release view, including the full per-interface diff, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev. This page focuses on the Component Model concepts themselves.
 
 ## Native async
 
-The Component Model's Canonical ABI defines how typed values cross component boundaries. Until WASI P3, that vocabulary had no notion of suspension or asynchronous completion; every interface call returned synchronously, and asynchronous I/O was modeled with resources (`pollable` for readiness, `input-stream` and `output-stream` for byte channels) scoped to whichever component obtained them.
+The Component Model's Canonical ABI defines how typed values cross component boundaries. Until WASI 0.3, that vocabulary had no notion of suspension or asynchronous completion; every interface call returned synchronously, and asynchronous I/O was modeled with resources (`pollable` for readiness, `input-stream` and `output-stream` for byte channels) scoped to whichever component obtained them.
 
 That arrangement holds up for two-party interactions, but it falters once components are composed in a chain. If a component awaits work that another component delegates further, the readiness signal has to travel back up the chain. When readiness is expressed as a resource scoped to a single component, the intermediate component is stuck running an event loop purely to forward the wake-up to its caller; the runtime cannot help, because the resource doesn't live in a place the runtime can reach across. This is sometimes called the **sandwich problem**: an async vocabulary that describes a single hop just fine but cannot propagate readiness past one.
 
@@ -40,7 +40,7 @@ A typed handle for a single value that will become available later. Like `stream
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 ```
 
-## How the primitives work in WASI P3
+## How the primitives work in WASI 0.3
 
 ### Stream plus terminal future
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -45,7 +45,7 @@ The same value can also be passed straight through a one or more components with
 read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 ```
 
-### `future<T>`
+### Futures (`future<T>`)
 
 A typed handle for a single value that will become available later. Like `stream<T>`, `future<T>` is a value rather than a resource, so it crosses component boundaries the same way a primitive does. A function returning `future<T>` does not block; the caller awaits the result when it needs it.
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -23,7 +23,7 @@ Native async primitives help close this expressivity gap. With updated Component
 
 Components can pass futures and streams along without keeping their own event loops running to relay readiness, as was necessary with WASI 0.2.
 
-## The three primitives
+## Async functions, Streams, and Futures
 
 ### `async func`
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -19,7 +19,9 @@ The Component Model's Canonical ABI defines how typed values cross component bou
 
 That arrangement holds up for two-party interactions, but it falters once components are composed in a chain. If a component awaits work that another component delegates further, the readiness signal has to travel back up the chain. When readiness is expressed as a resource scoped to a single component, the intermediate component is stuck running an event loop purely to forward the wake-up to its caller; the runtime cannot help, because the resource doesn't live in a place the runtime can reach across. This is sometimes called the **sandwich problem**: an async vocabulary that describes a single hop just fine but cannot propagate readiness past one.
 
-Native primitives close the gap. With `async func`, `stream<T>`, and `future<T>` in the Canonical ABI, scheduling and wake-up propagation become the runtime's job rather than any individual component's. Components can pass futures and streams along the chain without keeping their own event loops running to relay readiness.
+Native async primitives help close this expressivity gap. With updated Component ABI mechanics that enable `async func`, `stream<T>`, and `future<T>` available at the WIT level, scheduling and wake-up propagation become the runtime's job rather than any individual component's. 
+
+Components can pass futures and streams along without keeping their own event loops running to relay readiness, as was necessary with WASI 0.2.
 
 ## The three primitives
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -2,41 +2,31 @@
 
 WASI P3 is built on three new Canonical ABI primitives in the Component Model: `async func`, `stream<T>`, and `future<T>`. Together, they let interfaces express asynchronous operations that compose across component boundaries.
 
-## Why native async?
+For migration mechanics (e.g., how a WASI P2 component maps onto these primitives) see [Migrating from WASI P2 to WASI P3](./migrating-to-p3.md). For the WASI release view, including the full per-interface diff, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev. This page focuses on the Component Model concepts themselves.
 
-WASI P2 modeled asynchronous I/O through the `wasi:io` package, which exposed three resources:
+## Native async
 
-- `pollable`: an opaque handle representing readiness
-- `input-stream`: a byte source
-- `output-stream`: a byte sink
+The Component Model's Canonical ABI defines how typed values cross component boundaries. Until WASI P3, that vocabulary had no notion of suspension or asynchronous completion; every interface call returned synchronously, and asynchronous I/O was modeled with resources (`pollable` for readiness, `input-stream` and `output-stream` for byte channels) scoped to whichever component obtained them.
 
-These work fine when a component talks directly to its host. They break down when components are composed. Consider a three-layer chain:
+That arrangement holds up for two-party interactions, but it falters once components are composed in a chain. If a component awaits work that another component delegates further, the readiness signal has to travel back up the chain. When readiness is expressed as a resource scoped to a single component, the intermediate component is stuck running an event loop purely to forward the wake-up to its caller; the runtime cannot help, because the resource doesn't live in a place the runtime can reach across. This is sometimes called the **sandwich problem**: an async vocabulary that describes a single hop just fine but cannot propagate readiness past one.
 
-```
-A → B → Host
-```
-
-Component A makes a call into Component B that requires waiting on the Host. B calls the Host, which returns a `pollable` representing the eventual completion of the work. That `pollable` is a Component Model resource scoped to B's instance — A cannot hold it, poll it, or name it. B would have to actively check the `pollable` and forward the wake-up to A, but there is no Canonical ABI hook for "when this `pollable` becomes ready, run this code in B." In practice the wake-up gets dropped, and B has to actively poll its own `pollable` just to relay readiness back to A.
-
-This is sometimes called the **sandwich problem**: WASI P2 could express async, but could not compose it across component boundaries.
-
-The Component Model solves this by pushing async down into the Canonical ABI. The runtime owns scheduling and wake-up propagation, so async works correctly regardless of how many components sit between a producer and a consumer.
+Native primitives close the gap. With `async func`, `stream<T>`, and `future<T>` in the Canonical ABI, scheduling and wake-up propagation become the runtime's job rather than any individual component's. Components can pass futures and streams along the chain without keeping their own event loops running to relay readiness.
 
 ## The three primitives
 
 ### `async func`
 
-A function declared as asynchronous in WIT:
+A WIT function declared `async` tells the runtime that the call may suspend before producing its result. The Canonical ABI handles the suspension and resumption; the guest doesn't see a `pollable`, and the host doesn't see a polling loop.
 
 ```wit
 handle: async func(request: request) -> result<response, error-code>;
 ```
 
-Bindings generators emit language-native async constructs: `async fn` in Rust, `Promise` in JavaScript, coroutines in Python.
+Code generated from the WIT picks up each language's natural async idiom: `async fn` in Rust, a `Promise`-returning function in JavaScript, a coroutine in Python.
 
 ### `stream<T>`
 
-A typed, asynchronous data channel. Unlike `input-stream` and `output-stream` in WASI P2, a `stream<T>` is a *value* that can be passed across component boundaries the same way a `u32` can.
+A typed, asynchronous channel for a sequence of `T` values. Crucially, `stream<T>` is a Canonical ABI *value*, not a resource: it can be returned from a call, accepted as a parameter, and handed from one component to another without giving up ownership of the underlying buffer. The same value can also be passed straight through a middle component without that component having to relay any wake-ups.
 
 ```wit
 read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
@@ -44,44 +34,32 @@ read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 
 ### `future<T>`
 
-A single-value async completion. Where WASI P2 used `pollable` resources, WASI P3 uses `future<T>` values.
+A typed handle for a single value that will become available later. Like `stream<T>`, `future<T>` is a value rather than a resource, so it crosses component boundaries the same way a primitive does. A function returning `future<T>` does not block; the caller awaits the result when it needs it.
 
 ```wit
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 ```
 
-## Common patterns
+## How the primitives work in WASI P3
 
-### The stream-plus-future pattern
+### Stream plus terminal future
 
-A recurring pattern in WASI P3 pairs a `stream<T>` with a `future` that signals completion or error:
+Reads return both a data channel and a completion handle, packed into a tuple:
 
 ```wit
 read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 ```
 
-The stream delivers data incrementally. Once the stream closes, the future resolves to indicate whether the operation completed successfully or encountered an error. This pattern appears in stdin, filesystem reads, TCP receives, and directory listings.
+The two halves are independent. The caller can consume the stream eagerly, sample it, or drop it part-way through; either way the future resolves once the operation has terminated, carrying the success-or-failure outcome. The same shape appears in stdin, filesystem reads, TCP receives, and directory listings.
 
-### The write-direction flip
+### Stream parameter, future return
 
-In WASI P2, write operations gave you an `output-stream` that you wrote into. In WASI P3, the direction is reversed: you pass in a `stream<u8>` and receive a `future<result>` that resolves when the write completes. This applies to stdout, stderr, filesystem writes, and TCP sends.
+Writes use the symmetric shape: the guest supplies the data as a `stream<u8>` parameter, and the host returns a `future` that resolves once it has consumed the stream. Stdout, stderr, filesystem writes, and TCP sends all follow this shape:
 
 ```wit
-// WASI P2: get a stream, write to it
-get-stdout: func() -> output-stream;
-
-// WASI P3: pass data in, get a completion future
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 ```
 
-## Tooling support
+## Where to go next
 
-`async func`, `stream<T>`, and `future<T>` are native Canonical ABI features in the Component Model, supported by:
-
-- [Wasmtime](https://wasmtime.dev/) 43 and later, via `-Sp3 -W component-model-async=y` when running components.
-- [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) with the `async` feature enabled, for Rust guest bindings.
-- [jco](https://github.com/bytecodealliance/jco) for JavaScript environments, via the `preview3-shim` package.
-
-For an end-to-end Rust example, see [Creating Runnable Components in Rust](../language-support/creating-runnable-components/rust.md). For the WIT-level details of how to declare these types in your own interfaces, see [WIT Reference](./wit.md).
-
-> For a broader overview of what changed in WASI P3, including per-interface diffs, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
+For an end-to-end Rust example that uses these primitives in practice, see [Creating Runnable Components in Rust](../language-support/creating-runnable-components/rust.md). For runtime support and CLI flags, see [Wasmtime](../running-components/wasmtime.md). For the WIT syntax in detail, see [WIT Reference](./wit.md).

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -1,6 +1,11 @@
 # Async, Streams, and Futures
 
-WASI 0.3 is built on three new Canonical ABI primitives in the Component Model: `async func`, `stream<T>`, and `future<T>`. Together, they let interfaces express asynchronous operations that compose across component boundaries.
+WASI 0.3 adds new Canonical ABI primitives to the Component Model that enable async functionality. Components that target WASI 0.3 can use the new features in their WIT files:
+* `async func` 
+* `stream<T>`
+* `future<T>`
+
+These new types let interfaces express asynchronous operations that compose across component boundaries.
 
 For migration mechanics (e.g., how a WASI 0.2 component maps onto these primitives) see [Migrating from WASI 0.2 to WASI 0.3](./migrating-to-p3.md). For the WASI release view, including the full per-interface diff, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev. This page focuses on the Component Model concepts themselves.
 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -37,7 +37,9 @@ Code generated from the WIT picks up each language's natural async idiom: `async
 
 ### Streams (`stream<T>`)
 
-A typed, asynchronous channel for a sequence of `T` values. Crucially, `stream<T>` is a Canonical ABI *value*, not a resource: it can be returned from a call, accepted as a parameter, and handed from one component to another without giving up ownership of the underlying buffer. The same value can also be passed straight through a middle component without that component having to relay any wake-ups.
+A typed, asynchronous channel for a sequence of `T` values. Crucially, `stream<T>` is a Canonical ABI *value*, not a resource (as opposed to WASI 0.2) -- it can be returned from a call, accepted as a parameter, and handed from one component to another without giving up ownership of the underlying buffer. 
+
+The same value can also be passed straight through a one or more components without those component(s) having to relay any wake-ups.
 
 ```wit
 read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -1,4 +1,4 @@
-# Async, Streams, and Futures
+# Native Async with WASI 0.3
 
 WASI 0.3 adds new Canonical ABI primitives to the Component Model that enable async functionality. Components that target WASI 0.3 can use the new features in their WIT files:
 * `async func` 

--- a/component-model/src/design/async.md
+++ b/component-model/src/design/async.md
@@ -35,7 +35,7 @@ A WIT function declared `async` tells the runtime that the call may suspend befo
 
 Code generated from the WIT picks up each language's natural async idiom: `async fn` in Rust, a `Promise`-returning function in JavaScript, a coroutine in Python.
 
-### `stream<T>`
+### Streams (`stream<T>`)
 
 A typed, asynchronous channel for a sequence of `T` values. Crucially, `stream<T>` is a Canonical ABI *value*, not a resource: it can be returned from a call, accepted as a parameter, and handed from one component to another without giving up ownership of the underlying buffer. The same value can also be passed straight through a middle component without that component having to relay any wake-ups.
 

--- a/component-model/src/design/component-model-concepts.md
+++ b/component-model/src/design/component-model-concepts.md
@@ -67,7 +67,7 @@ and a `proxy` world that depends on `imports`.
 
 ### Async, Streams, and Futures
 
-The Component Model includes [`async func`, `stream<T>`, and `future<T>`](./async.md) as native Canonical ABI primitives, introduced alongside WASI P3. Together, they let interfaces express asynchronous operations that compose across component boundaries.
+The Component Model includes [`async func`, `stream<T>`, and `future<T>`](./async.md) as native Canonical ABI primitives, introduced alongside WASI 0.3. Together, they let interfaces express asynchronous operations that compose across component boundaries.
 
 ### Platforms
 

--- a/component-model/src/design/component-model-concepts.md
+++ b/component-model/src/design/component-model-concepts.md
@@ -65,6 +65,10 @@ For example, the [wasi-http](https://github.com/WebAssembly/WASI/blob/main/propo
 an `imports` world encapsulating the interfaces that an HTTP proxy depends on,
 and a `proxy` world that depends on `imports`.
 
+### Async, Streams, and Futures
+
+The Component Model includes [`async func`, `stream<T>`, and `future<T>`](./async.md) as native Canonical ABI primitives, introduced alongside WASI P3. Together, they let interfaces express asynchronous operations that compose across component boundaries.
+
 ### Platforms
 
 In the context of WebAssembly, a _host_ refers to a WebAssembly runtime

--- a/component-model/src/design/component-model-concepts.md
+++ b/component-model/src/design/component-model-concepts.md
@@ -67,7 +67,7 @@ and a `proxy` world that depends on `imports`.
 
 ### Async, Streams, and Futures
 
-The Component Model includes [`async func`, `stream<T>`, and `future<T>`](./async.md) as native Canonical ABI primitives, introduced alongside WASI 0.3. Together, they let interfaces express asynchronous operations that compose across component boundaries.
+New Component Model primitives that enable use of [`async func`, `stream<T>`, and `future<T>`](./async.md), were introduced alongside WASI 0.3. Together, they let interfaces express asynchronous operations that compose across component boundaries.
 
 ### Platforms
 

--- a/component-model/src/design/migrating-to-p3.md
+++ b/component-model/src/design/migrating-to-p3.md
@@ -1,0 +1,129 @@
+# Migrating from WASI P2 to WASI P3
+
+WASI P3 reshapes WASI's interfaces around the [native async primitives](./async.md) — `async func`, `stream<T>`, and `future<T>` — that the Component Model added for this release. Most of the per-package changes in `wasi:cli`, `wasi:http`, `wasi:filesystem`, and `wasi:sockets` are mechanical consequences of moving onto these primitives.
+
+This page covers the mapping. For a worked WIT-level diff of every WASI P3 interface, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
+
+## Do you need to migrate?
+
+Not immediately. WASI P3 runtimes can polyfill P2 by mapping P2 imports onto native P3 primitives at the host boundary, and Wasmtime's `wasmtime serve` already runs both P3 and P2 components from the same binary, dispatching per component. Migration is the right call when you want:
+
+- Composable async across component boundaries (the [sandwich problem](./async.md#why-native-async) goes away).
+- The newer interface shapes — in particular, `wasi:http`'s collapse of eight resources down to two.
+- First-class support in P3-targeted toolchains as they continue to land.
+
+## Concept mapping
+
+WASI P3 replaces every `wasi:io` resource with a Canonical ABI primitive. The translation is mostly one-to-one:
+
+| WASI P2 (`wasi:io`)              | WASI P3 (Component Model)                |
+| -------------------------------- | ---------------------------------------- |
+| `resource pollable`              | `future<T>`                              |
+| `resource input-stream`          | `stream<u8>`                             |
+| `resource output-stream`         | `stream<u8>` (passed *into* the call)    |
+| `poll(list<pollable>)`           | `await` on a future                      |
+| `subscribe()` on a resource      | return a `future` from the call          |
+| `start-foo` / `finish-foo`       | a single `func` or `async func`          |
+
+## What changed in WIT
+
+Three patterns appear over and over in the rebased interfaces.
+
+### Stream-plus-future for reads
+
+In P2, a read call returned an `input-stream`. In P3, it returns a tuple of a `stream<u8>` plus a `future<result<_, error-code>>` that resolves once the stream closes:
+
+```wit
+// WASI P2 (filesystem read)
+read-via-stream: func(offset: filesize) -> result<input-stream, error-code>;
+
+// WASI P3 (filesystem read)
+read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
+```
+
+The stream delivers data incrementally. The future signals terminal success or failure independently of how much of the stream the caller consumes.
+
+### Write-direction flip
+
+P2 write calls handed you an `output-stream` to write into. P3 reverses the direction: you pass a `stream<u8>` *into* the call and receive a `future<result>` that resolves when the write completes:
+
+```wit
+// WASI P2: get a stream, write into it
+get-stdout: func() -> output-stream;
+
+// WASI P3: pass data in, get a completion future
+write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
+```
+
+### Two-step calls collapsed
+
+P2 modeled operations that could suspend as a `start-foo` / `finish-foo` pair, with a `pollable` for readiness in between. P3 collapses each pair into a single call:
+
+```wit
+// WASI P2
+start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
+
+// WASI P3
+connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
+```
+
+The collapsed call is `async func` when the operation needs to suspend in the host (such as `connect`); operations that historically only used the two-step shape for non-blocking dispatch may collapse to plain `func` instead (`bind`, `listen`).
+
+## Per-interface notes
+
+### `wasi:io` (removed)
+
+The package is gone. Everything it expressed is now Canonical ABI primitives.
+
+### `wasi:http`
+
+The most dramatic restructuring. The eight P2 resources — `incoming-request`, `outgoing-request`, `incoming-response`, `outgoing-response`, `incoming-body`, `outgoing-body`, `future-trailers`, and `future-incoming-response` — collapse to two: `request` and `response`. Bodies are `stream<u8>`; trailers are a `future`. The handler is an `async func`:
+
+```wit
+// WASI P2
+handle: func(request: incoming-request, response-out: response-outparam);
+
+// WASI P3
+handle: async func(request: request) -> result<response, error-code>;
+```
+
+The `proxy` world is replaced by `service`, with a new `middleware` world that imports and exports the handler.
+
+### `wasi:sockets`
+
+The seven P2 interfaces (`network`, `instance-network`, `tcp`, `tcp-create-socket`, `udp`, `udp-create-socket`, `ip-name-lookup`) collapse to a unified `types` interface containing both `tcp-socket` and `udp-socket` resources, plus `ip-name-lookup`. The `network` resource is removed entirely — network access is now granted at the world level. `start-*` / `finish-*` pairs collapse as described above. TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` call.
+
+### `wasi:filesystem`
+
+Most `descriptor` methods are `async func`. Streaming reads and writes use the stream-plus-future pattern; `read-directory` returns `stream<directory-entry>`. The `error-code` enum gains a catch-all `other(option<string>)` variant.
+
+### `wasi:cli`
+
+stdin, stdout, and stderr use `stream<u8>` with the stream-plus-future pattern. `run` becomes `async func`. A shared `wasi:cli/types` interface carries an `error-code` variant. The `exit-with-code` function stabilizes alongside `exit`.
+
+### `wasi:clocks`
+
+`wall-clock` is renamed to `system-clock`, and `datetime` is renamed to `instant`. The `instant` record uses `s64` seconds (instead of `u64`), supporting pre-epoch timestamps. `subscribe-instant` and `subscribe-duration` are replaced by `wait-until` and `wait-for` `async func`s.
+
+### `wasi:random`
+
+The `len` parameter is renamed to `max-len` on `get-random-bytes` and `get-insecure-random-bytes`. Implementations may now return fewer bytes than requested, so callers should loop.
+
+## Tooling requirements
+
+| Tool          | Minimum                                                         | Notes                                                               |
+| ------------- | --------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Wasmtime      | 43+ for `wasmtime run`; 44+ for `wasmtime serve`                | Enable with `-Sp3 -W component-model-async=y`.                      |
+| `wit-bindgen` | 0.46+                                                           | Use the `async` feature for P3 binding generation.                  |
+| jco           | latest                                                          | P3 host bindings ship in the `preview3-shim` package.               |
+| `wkg`         | 0.15+                                                           | Required to fetch `wasi:cli@0.3.0-rc-2026-03-15` and related packages. |
+| Rust          | nightly                                                         | Current stable bundles a `wasm-component-ld` too old for P3 outputs of `wit-bindgen` 0.58. |
+
+> **Version pinning.** As of WASI 0.3.0's release on 2026-06-11, Wasmtime and `wit-bindgen` still vendor the `0.3.0-rc-2026-03-15` snapshot of the WIT. Components pinning to the published `0.3.0` will fail to instantiate against current Wasmtime; use the RC pin until those tools refresh.
+
+## Further reading
+
+- [Async, Streams, and Futures](./async.md) — the conceptual foundation
+- [Creating Runnable Components in Rust](../language-support/creating-runnable-components/rust.md) — worked Rust example with the P3 `async fn run()` pattern
+- [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev — full WIT-level diff per interface

--- a/component-model/src/design/migrating-to-p3.md
+++ b/component-model/src/design/migrating-to-p3.md
@@ -8,8 +8,8 @@ This page covers the mapping between concepts in WASI P2 and WASI P3. For a WIT-
 
 Not immediately. WASI P3 runtimes can polyfill P2 by mapping P2 imports onto native P3 primitives at the host boundary, and Wasmtime's `wasmtime serve` already runs both P3 and P2 components from the same binary, dispatching per component. Migration is the right call when you want:
 
-- Composable async across component boundaries (the [sandwich problem](./async.md#why-native-async) goes away).
-- The newer interface shapes — in particular, `wasi:http`'s collapse of eight resources down to two.
+- Composable async across component boundaries (the [sandwich problem](./async.md#native-async) goes away).
+- The newer interface shapes — in particular, `wasi:http`'s collapse of nine resources down to two.
 - First-class support in P3-targeted toolchains as they continue to land.
 
 ## Concept mapping
@@ -29,7 +29,7 @@ WASI P3 replaces every `wasi:io` resource with a Canonical ABI primitive. The tr
 
 ### Stream-plus-future for reads
 
-In P2, a read call returned an `input-stream`. In P3, it returns a tuple of a `stream<u8>` plus a `future<result<_, error-code>>` that resolves once the stream closes:
+A P2 read call returned a single `input-stream` resource and surfaced terminal errors only as you consumed it. P3 splits those concerns: the call returns a `stream<u8>` for the data and a `future<result<_, error-code>>` for the outcome, packed into a tuple.
 
 ```wit
 // WASI P2 (filesystem read)
@@ -39,17 +39,17 @@ read-via-stream: func(offset: filesize) -> result<input-stream, error-code>;
 read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
 ```
 
-The stream delivers data incrementally. The future signals terminal success or failure independently of how much of the stream the caller consumes.
+In P3 the caller does not have to drain the stream to learn whether the read finished cleanly; the future resolves either way.
 
 ### Write-direction flip
 
-P2 write calls handed you an `output-stream` to write into. P3 reverses the direction: you pass a `stream<u8>` *into* the call and receive a `future<result>` that resolves when the write completes:
+P2 write paths handed a guest some host-owned resource (an `output-stream`) and let the guest push bytes into it. P3 inverts that: the guest supplies the data as a `stream<u8>` value, and the host returns a `future` that resolves once it has finished consuming the stream.
 
 ```wit
-// WASI P2: get a stream, write into it
+// WASI P2: receive an output-stream resource, write into it
 get-stdout: func() -> output-stream;
 
-// WASI P3: pass data in, get a completion future
+// WASI P3: pass a stream value in, receive a completion future
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 ```
 
@@ -68,15 +68,12 @@ connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
 
 The collapsed call is `async func` when the operation needs to suspend in the host (such as `connect`); operations that historically only used the two-step shape for non-blocking dispatch may collapse to plain `func` instead (`bind`, `listen`).
 
-## Interface notes
+## Interface highlights
 
-### `wasi:io` (removed)
+The complete per-interface diff lives on [WASI P3](https://wasi.dev/releases/wasi-p3#what-changed-in-each-interface) at WASI.dev. The three changes most likely to drive migration work are:
 
-The package is gone. Everything it expressed is now Canonical ABI primitives.
-
-### `wasi:http`
-
-The most dramatic restructuring. The eight P2 resources (`incoming-request`, `outgoing-request`, `incoming-response`, `outgoing-response`, `incoming-body`, `outgoing-body`, `future-trailers`, and `future-incoming-response`) collapse to two: `request` and `response`. Bodies are `stream<u8>`; trailers are a `future`. The handler is an `async func`:
+- **`wasi:io` is gone.** The package has no 0.3.0 release. Every resource it exposed (`pollable`, `input-stream`, `output-stream`) is replaced by a Component Model primitive, per the [concept mapping](#concept-mapping) above.
+- **`wasi:http` collapses from nine resources to two.** The incoming/outgoing × request/response/body matrix plus `future-trailers`, `future-incoming-response`, and `response-outparam` all become `request` and `response`, with `stream<u8>` bodies and a `future` for trailers. The handler is now an `async func`:
 
 ```wit
 // WASI P2
@@ -86,27 +83,10 @@ handle: func(request: incoming-request, response-out: response-outparam);
 handle: async func(request: request) -> result<response, error-code>;
 ```
 
-The `proxy` world is replaced by `service`, with a new `middleware` world that imports and exports the handler.
+The `proxy` world is replaced by `service`, and a new `middleware` world both imports and exports the handler.
+- **`wasi:sockets` drops its `network` resource.** Network access is granted at the world level instead of being threaded through every `bind`, `connect`, and DNS lookup. The seven P2 socket interfaces consolidate into one `types` interface plus `ip-name-lookup`, and TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` loop.
 
-### `wasi:sockets`
-
-The seven P2 interfaces (`network`, `instance-network`, `tcp`, `tcp-create-socket`, `udp`, `udp-create-socket`, `ip-name-lookup`) collapse to a unified `types` interface containing both `tcp-socket` and `udp-socket` resources, plus `ip-name-lookup`. The `network` resource is removed entirely; network access is now granted at the world level. `start-*` / `finish-*` pairs collapse as described above. TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` call.
-
-### `wasi:filesystem`
-
-Most `descriptor` methods are `async func`. Streaming reads and writes use the stream-plus-future pattern; `read-directory` returns `stream<directory-entry>`. The `error-code` enum gains a catch-all `other(option<string>)` variant.
-
-### `wasi:cli`
-
-stdin, stdout, and stderr use `stream<u8>` with the stream-plus-future pattern. `run` becomes `async func`. A shared `wasi:cli/types` interface carries an `error-code` variant. The `exit-with-code` function stabilizes alongside `exit`.
-
-### `wasi:clocks`
-
-`wall-clock` is renamed to `system-clock`, and `datetime` is renamed to `instant`. The `instant` record uses `s64` seconds (instead of `u64`), supporting pre-epoch timestamps. `subscribe-instant` and `subscribe-duration` are replaced by `wait-until` and `wait-for` `async func`s.
-
-### `wasi:random`
-
-The `len` parameter is renamed to `max-len` on `get-random-bytes` and `get-insecure-random-bytes`. Implementations may now return fewer bytes than requested, so callers should loop.
+Smaller per-interface changes — filesystem methods becoming `async func`, the `wasi:clocks` rename pass (`wall-clock` → `system-clock`, `datetime` → `instant`), the `max-len` rename in `wasi:random`, the new shared `wasi:cli/types` interface — are documented in the WASI.dev page linked above.
 
 ## Tooling requirements
 

--- a/component-model/src/design/migrating-to-p3.md
+++ b/component-model/src/design/migrating-to-p3.md
@@ -1,8 +1,8 @@
 # Migrating from WASI P2 to WASI P3
 
-WASI P3 reshapes WASI's interfaces around the [native async primitives](./async.md) — `async func`, `stream<T>`, and `future<T>` — that the Component Model added for this release. Most of the per-package changes in `wasi:cli`, `wasi:http`, `wasi:filesystem`, and `wasi:sockets` are mechanical consequences of moving onto these primitives.
+WASI P3 reshapes WASI's interfaces around the [native async primitives](./async.md) `async func`, `stream<T>`, and `future<T>`. Most of the changes in `wasi:cli`, `wasi:http`, `wasi:filesystem`, and `wasi:sockets` are consequences of moving to these primitives.
 
-This page covers the mapping. For a worked WIT-level diff of every WASI P3 interface, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
+This page covers the mapping between concepts in WASI P2 and WASI P3. For a WIT-level comparison of every WASI P3 interface, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
 
 ## Do you need to migrate?
 
@@ -26,8 +26,6 @@ WASI P3 replaces every `wasi:io` resource with a Canonical ABI primitive. The tr
 | `start-foo` / `finish-foo`       | a single `func` or `async func`          |
 
 ## What changed in WIT
-
-Three patterns appear over and over in the rebased interfaces.
 
 ### Stream-plus-future for reads
 
@@ -70,7 +68,7 @@ connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
 
 The collapsed call is `async func` when the operation needs to suspend in the host (such as `connect`); operations that historically only used the two-step shape for non-blocking dispatch may collapse to plain `func` instead (`bind`, `listen`).
 
-## Per-interface notes
+## Interface notes
 
 ### `wasi:io` (removed)
 
@@ -78,7 +76,7 @@ The package is gone. Everything it expressed is now Canonical ABI primitives.
 
 ### `wasi:http`
 
-The most dramatic restructuring. The eight P2 resources — `incoming-request`, `outgoing-request`, `incoming-response`, `outgoing-response`, `incoming-body`, `outgoing-body`, `future-trailers`, and `future-incoming-response` — collapse to two: `request` and `response`. Bodies are `stream<u8>`; trailers are a `future`. The handler is an `async func`:
+The most dramatic restructuring. The eight P2 resources (`incoming-request`, `outgoing-request`, `incoming-response`, `outgoing-response`, `incoming-body`, `outgoing-body`, `future-trailers`, and `future-incoming-response`) collapse to two: `request` and `response`. Bodies are `stream<u8>`; trailers are a `future`. The handler is an `async func`:
 
 ```wit
 // WASI P2
@@ -92,7 +90,7 @@ The `proxy` world is replaced by `service`, with a new `middleware` world that i
 
 ### `wasi:sockets`
 
-The seven P2 interfaces (`network`, `instance-network`, `tcp`, `tcp-create-socket`, `udp`, `udp-create-socket`, `ip-name-lookup`) collapse to a unified `types` interface containing both `tcp-socket` and `udp-socket` resources, plus `ip-name-lookup`. The `network` resource is removed entirely — network access is now granted at the world level. `start-*` / `finish-*` pairs collapse as described above. TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` call.
+The seven P2 interfaces (`network`, `instance-network`, `tcp`, `tcp-create-socket`, `udp`, `udp-create-socket`, `ip-name-lookup`) collapse to a unified `types` interface containing both `tcp-socket` and `udp-socket` resources, plus `ip-name-lookup`. The `network` resource is removed entirely; network access is now granted at the world level. `start-*` / `finish-*` pairs collapse as described above. TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` call.
 
 ### `wasi:filesystem`
 

--- a/component-model/src/design/migrating-to-p3.md
+++ b/component-model/src/design/migrating-to-p3.md
@@ -29,7 +29,7 @@ WASI 0.3 replaces every `wasi:io` resource with a Canonical ABI primitive. The t
 
 ### Stream-plus-future for reads
 
-A 0.2 read call returned a single `input-stream` resource and surfaced terminal errors only as you consumed it. 0.3 splits those concerns: the call returns a `stream<u8>` for the data and a `future<result<_, error-code>>` for the outcome, packed into a tuple.
+A WASI 0.2 read call returned a single `input-stream` resource and surfaced terminal errors only as you consumed it. WASI 0.3 splits those concerns: the call returns a `stream<u8>` for the data and a `future<result<_, error-code>>` for the outcome, packed into a tuple.
 
 ```wit
 // WASI 0.2 (filesystem read)
@@ -39,11 +39,11 @@ read-via-stream: func(offset: filesize) -> result<input-stream, error-code>;
 read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
 ```
 
-In 0.3 the caller does not have to drain the stream to learn whether the read finished cleanly; the future resolves either way.
+In WASI 0.3, the caller does not have to drain the stream to learn whether the read finished cleanly; the future resolves either way.
 
 ### Write-direction flip
 
-0.2 write paths handed a guest some host-owned resource (an `output-stream`) and let the guest push bytes into it. 0.3 inverts that: the guest supplies the data as a `stream<u8>` value, and the host returns a `future` that resolves once it has finished consuming the stream.
+WASI 0.2 write paths handed a guest some host-owned resource (an `output-stream`) and let the guest push bytes into it. WASI 0.3 inverts that: the guest supplies the data as a `stream<u8>` value, and the host returns a `future` that resolves once it has finished consuming the stream.
 
 ```wit
 // WASI 0.2: receive an output-stream resource, write into it
@@ -55,7 +55,7 @@ write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 
 ### Two-step calls collapsed
 
-0.2 modeled operations that could suspend as a `start-foo` / `finish-foo` pair, with a `pollable` for readiness in between. 0.3 collapses each pair into a single call:
+WASI 0.2 modeled operations that could suspend as a `start-foo` / `finish-foo` pair, with a `pollable` for readiness in between. WASI 0.3 collapses each pair into a single call:
 
 ```wit
 // WASI 0.2
@@ -84,7 +84,7 @@ handle: async func(request: request) -> result<response, error-code>;
 ```
 
 The `proxy` world is replaced by `service`, and a new `middleware` world both imports and exports the handler.
-- **`wasi:sockets` drops its `network` resource.** Network access is granted at the world level instead of being threaded through every `bind`, `connect`, and DNS lookup. The seven 0.2 socket interfaces consolidate into one `types` interface plus `ip-name-lookup`, and TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` loop.
+- **`wasi:sockets` drops its `network` resource.** Network access is granted at the world level instead of being threaded through every `bind`, `connect`, and DNS lookup. The seven WASI 0.2 socket interfaces consolidate into one `types` interface plus `ip-name-lookup`, and TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` loop.
 
 Smaller per-interface changes — filesystem methods becoming `async func`, the `wasi:clocks` rename pass (`wall-clock` → `system-clock`, `datetime` → `instant`), the `max-len` rename in `wasi:random`, the new shared `wasi:cli/types` interface — are documented in the WASI.dev page linked above.
 

--- a/component-model/src/design/migrating-to-p3.md
+++ b/component-model/src/design/migrating-to-p3.md
@@ -1,22 +1,22 @@
-# Migrating from WASI P2 to WASI P3
+# Migrating from WASI 0.2 to WASI 0.3
 
-WASI P3 reshapes WASI's interfaces around the [native async primitives](./async.md) `async func`, `stream<T>`, and `future<T>`. Most of the changes in `wasi:cli`, `wasi:http`, `wasi:filesystem`, and `wasi:sockets` are consequences of moving to these primitives.
+WASI 0.3 reshapes WASI's interfaces around the [native async primitives](./async.md) `async func`, `stream<T>`, and `future<T>`. Most of the changes in `wasi:cli`, `wasi:http`, `wasi:filesystem`, and `wasi:sockets` are consequences of moving to these primitives.
 
-This page covers the mapping between concepts in WASI P2 and WASI P3. For a WIT-level comparison of every WASI P3 interface, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
+This page covers the mapping between concepts in WASI 0.2 and WASI 0.3. For a WIT-level comparison of every WASI 0.3 interface, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
 
 ## Do you need to migrate?
 
-Not immediately. WASI P3 runtimes can polyfill P2 by mapping P2 imports onto native P3 primitives at the host boundary, and Wasmtime's `wasmtime serve` already runs both P3 and P2 components from the same binary, dispatching per component. Migration is the right call when you want:
+Not immediately. WASI 0.3 runtimes can polyfill 0.2 by mapping 0.2 imports onto native 0.3 primitives at the host boundary, and Wasmtime's `wasmtime serve` already runs both 0.3 and 0.2 components from the same binary, dispatching per component. Migration is the right call when you want:
 
 - Composable async across component boundaries (the [sandwich problem](./async.md#native-async) goes away).
 - The newer interface shapes — in particular, `wasi:http`'s collapse of nine resources down to two.
-- First-class support in P3-targeted toolchains as they continue to land.
+- First-class support in 0.3-targeted toolchains as they continue to land.
 
 ## Concept mapping
 
-WASI P3 replaces every `wasi:io` resource with a Canonical ABI primitive. The translation is mostly one-to-one:
+WASI 0.3 replaces every `wasi:io` resource with a Canonical ABI primitive. The translation is mostly one-to-one:
 
-| WASI P2 (`wasi:io`)              | WASI P3 (Component Model)                |
+| WASI 0.2 (`wasi:io`)              | WASI 0.3 (Component Model)                |
 | -------------------------------- | ---------------------------------------- |
 | `resource pollable`              | `future<T>`                              |
 | `resource input-stream`          | `stream<u8>`                             |
@@ -29,40 +29,40 @@ WASI P3 replaces every `wasi:io` resource with a Canonical ABI primitive. The tr
 
 ### Stream-plus-future for reads
 
-A P2 read call returned a single `input-stream` resource and surfaced terminal errors only as you consumed it. P3 splits those concerns: the call returns a `stream<u8>` for the data and a `future<result<_, error-code>>` for the outcome, packed into a tuple.
+A 0.2 read call returned a single `input-stream` resource and surfaced terminal errors only as you consumed it. 0.3 splits those concerns: the call returns a `stream<u8>` for the data and a `future<result<_, error-code>>` for the outcome, packed into a tuple.
 
 ```wit
-// WASI P2 (filesystem read)
+// WASI 0.2 (filesystem read)
 read-via-stream: func(offset: filesize) -> result<input-stream, error-code>;
 
-// WASI P3 (filesystem read)
+// WASI 0.3 (filesystem read)
 read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
 ```
 
-In P3 the caller does not have to drain the stream to learn whether the read finished cleanly; the future resolves either way.
+In 0.3 the caller does not have to drain the stream to learn whether the read finished cleanly; the future resolves either way.
 
 ### Write-direction flip
 
-P2 write paths handed a guest some host-owned resource (an `output-stream`) and let the guest push bytes into it. P3 inverts that: the guest supplies the data as a `stream<u8>` value, and the host returns a `future` that resolves once it has finished consuming the stream.
+0.2 write paths handed a guest some host-owned resource (an `output-stream`) and let the guest push bytes into it. 0.3 inverts that: the guest supplies the data as a `stream<u8>` value, and the host returns a `future` that resolves once it has finished consuming the stream.
 
 ```wit
-// WASI P2: receive an output-stream resource, write into it
+// WASI 0.2: receive an output-stream resource, write into it
 get-stdout: func() -> output-stream;
 
-// WASI P3: pass a stream value in, receive a completion future
+// WASI 0.3: pass a stream value in, receive a completion future
 write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
 ```
 
 ### Two-step calls collapsed
 
-P2 modeled operations that could suspend as a `start-foo` / `finish-foo` pair, with a `pollable` for readiness in between. P3 collapses each pair into a single call:
+0.2 modeled operations that could suspend as a `start-foo` / `finish-foo` pair, with a `pollable` for readiness in between. 0.3 collapses each pair into a single call:
 
 ```wit
-// WASI P2
+// WASI 0.2
 start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
 finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 
-// WASI P3
+// WASI 0.3
 connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
 ```
 
@@ -70,21 +70,21 @@ The collapsed call is `async func` when the operation needs to suspend in the ho
 
 ## Interface highlights
 
-The complete per-interface diff lives on [WASI P3](https://wasi.dev/releases/wasi-p3#what-changed-in-each-interface) at WASI.dev. The three changes most likely to drive migration work are:
+The complete per-interface diff lives on [WASI 0.3](https://wasi.dev/releases/wasi-p3#what-changed-in-each-interface) at WASI.dev. The three changes most likely to drive migration work are:
 
 - **`wasi:io` is gone.** The package has no 0.3.0 release. Every resource it exposed (`pollable`, `input-stream`, `output-stream`) is replaced by a Component Model primitive, per the [concept mapping](#concept-mapping) above.
 - **`wasi:http` collapses from nine resources to two.** The incoming/outgoing × request/response/body matrix plus `future-trailers`, `future-incoming-response`, and `response-outparam` all become `request` and `response`, with `stream<u8>` bodies and a `future` for trailers. The handler is now an `async func`:
 
 ```wit
-// WASI P2
+// WASI 0.2
 handle: func(request: incoming-request, response-out: response-outparam);
 
-// WASI P3
+// WASI 0.3
 handle: async func(request: request) -> result<response, error-code>;
 ```
 
 The `proxy` world is replaced by `service`, and a new `middleware` world both imports and exports the handler.
-- **`wasi:sockets` drops its `network` resource.** Network access is granted at the world level instead of being threaded through every `bind`, `connect`, and DNS lookup. The seven P2 socket interfaces consolidate into one `types` interface plus `ip-name-lookup`, and TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` loop.
+- **`wasi:sockets` drops its `network` resource.** Network access is granted at the world level instead of being threaded through every `bind`, `connect`, and DNS lookup. The seven 0.2 socket interfaces consolidate into one `types` interface plus `ip-name-lookup`, and TCP `listen` returns `stream<tcp-socket>` directly instead of requiring a separate `accept` loop.
 
 Smaller per-interface changes — filesystem methods becoming `async func`, the `wasi:clocks` rename pass (`wall-clock` → `system-clock`, `datetime` → `instant`), the `max-len` rename in `wasi:random`, the new shared `wasi:cli/types` interface — are documented in the WASI.dev page linked above.
 
@@ -93,15 +93,15 @@ Smaller per-interface changes — filesystem methods becoming `async func`, the 
 | Tool          | Minimum                                                         | Notes                                                               |
 | ------------- | --------------------------------------------------------------- | ------------------------------------------------------------------- |
 | Wasmtime      | 43+ for `wasmtime run`; 44+ for `wasmtime serve`                | Enable with `-Sp3 -W component-model-async=y`.                      |
-| `wit-bindgen` | 0.46+                                                           | Use the `async` feature for P3 binding generation.                  |
-| jco           | latest                                                          | P3 host bindings ship in the `preview3-shim` package.               |
+| `wit-bindgen` | 0.46+                                                           | Use the `async` feature for 0.3 binding generation.                  |
+| jco           | latest                                                          | 0.3 host bindings ship in the `preview3-shim` package.               |
 | `wkg`         | 0.15+                                                           | Required to fetch `wasi:cli@0.3.0-rc-2026-03-15` and related packages. |
-| Rust          | nightly                                                         | Current stable bundles a `wasm-component-ld` too old for P3 outputs of `wit-bindgen` 0.58. |
+| Rust          | nightly                                                         | Current stable bundles a `wasm-component-ld` too old for 0.3 outputs of `wit-bindgen` 0.58. |
 
 > **Version pinning.** As of WASI 0.3.0's release on 2026-06-11, Wasmtime and `wit-bindgen` still vendor the `0.3.0-rc-2026-03-15` snapshot of the WIT. Components pinning to the published `0.3.0` will fail to instantiate against current Wasmtime; use the RC pin until those tools refresh.
 
 ## Further reading
 
 - [Async, Streams, and Futures](./async.md) — the conceptual foundation
-- [Creating Runnable Components in Rust](../language-support/creating-runnable-components/rust.md) — worked Rust example with the P3 `async fn run()` pattern
-- [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev — full WIT-level diff per interface
+- [Creating Runnable Components in Rust](../language-support/creating-runnable-components/rust.md) — worked Rust example with the 0.3 `async fn run()` pattern
+- [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev — full WIT-level diff per interface

--- a/component-model/src/design/migrating-to-p3.md
+++ b/component-model/src/design/migrating-to-p3.md
@@ -6,7 +6,9 @@ This page covers the mapping between concepts in WASI 0.2 and WASI 0.3. For a WI
 
 ## Do you need to migrate?
 
-Not immediately. WASI 0.3 runtimes can polyfill 0.2 by mapping 0.2 imports onto native 0.3 primitives at the host boundary, and Wasmtime's `wasmtime serve` already runs both 0.3 and 0.2 components from the same binary, dispatching per component. Migration is the right call when you want:
+Not immediately -- WASI 0.2 can be used in hosts just as before, WASI 0.3 is a purely additive change.
+
+Separately, WASI 0.3 runtimes can polyfill 0.2 by mapping 0.2 imports onto native 0.3 primitives at the host boundary, and Wasmtime's `wasmtime serve` already runs both 0.3 and 0.2 components from the same binary, dispatching per component. Migration is the right call when you want:
 
 - Composable async across component boundaries (the [sandwich problem](./async.md#native-async) goes away).
 - The newer interface shapes — in particular, `wasi:http`'s collapse of nine resources down to two.

--- a/component-model/src/design/migrating-to-p3.md
+++ b/component-model/src/design/migrating-to-p3.md
@@ -10,7 +10,7 @@ Not immediately -- WASI 0.2 can be used in hosts just as before, WASI 0.3 is a p
 
 Separately, WASI 0.3 runtimes can polyfill 0.2 by mapping 0.2 imports onto native 0.3 primitives at the host boundary, and Wasmtime's `wasmtime serve` already runs both 0.3 and 0.2 components from the same binary, dispatching per component. Migration is the right call when you want:
 
-- Composable async across component boundaries (the [sandwich problem](./async.md#native-async) goes away).
+- Composable async across component boundaries (the [sandwich problem](./async.md#the-async-problem-that-wasi-03-solves) goes away).
 - The newer interface shapes — in particular, `wasi:http`'s collapse of nine resources down to two.
 - First-class support in 0.3-targeted toolchains as they continue to land.
 
@@ -94,13 +94,11 @@ Smaller per-interface changes — filesystem methods becoming `async func`, the 
 
 | Tool          | Minimum                                                         | Notes                                                               |
 | ------------- | --------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Wasmtime      | 43+ for `wasmtime run`; 44+ for `wasmtime serve`                | Enable with `-Sp3 -W component-model-async=y`.                      |
+| Wasmtime      | 46+                                                             | WASI 0.3 and `component-model-async` are on by default.              |
 | `wit-bindgen` | 0.46+                                                           | Use the `async` feature for 0.3 binding generation.                  |
 | jco           | latest                                                          | 0.3 host bindings ship in the `preview3-shim` package.               |
-| `wkg`         | 0.15+                                                           | Required to fetch `wasi:cli@0.3.0-rc-2026-03-15` and related packages. |
+| `wkg`         | 0.15+                                                           | Required to fetch `wasi:cli@0.3.0` and related packages.             |
 | Rust          | nightly                                                         | Current stable bundles a `wasm-component-ld` too old for 0.3 outputs of `wit-bindgen` 0.58. |
-
-> **Version pinning.** As of WASI 0.3.0's release on 2026-06-11, Wasmtime and `wit-bindgen` still vendor the `0.3.0-rc-2026-03-15` snapshot of the WIT. Components pinning to the published `0.3.0` will fail to instantiate against current Wasmtime; use the RC pin until those tools refresh.
 
 ## Further reading
 

--- a/component-model/src/reference/faq.md
+++ b/component-model/src/reference/faq.md
@@ -96,7 +96,7 @@ More precisely, a Preview 1 "component" is a WebAssembly core module with a well
 
 ## Q: What is WASI 0.3?
 
-WASI 0.3 (WASI 0.3) is the latest milestone release of WASI, published on June 11, 2026.
+WASI 0.3 is the latest milestone release of WASI, published on June 11, 2026.
 It rebases WASI's interfaces onto three new Canonical ABI primitives that the Component Model added for this release:
 [`async func`, `stream<T>`, and `future<T>`](../design/async.md).
 The `wasi:io` package is removed; its functionality is now provided by the Component Model directly.

--- a/component-model/src/reference/faq.md
+++ b/component-model/src/reference/faq.md
@@ -77,18 +77,62 @@ expect to access—WASI enables building interfaces on top of a shared standard 
 [wit]: https://component-model.bytecodealliance.org/design/wit.html
 [wasi-http]: https://github.com/WebAssembly/WASI/tree/main/proposals/http
 
-## Q: I see the terms Preview 1 and Preview 2 frequently. What do those refer to?
+## Q: I see the terms Preview 1, Preview 2, and Preview 3 frequently. What do those refer to?
 
 Preview 1 refers to [the first iteration of the Component Model](https://github.com/WebAssembly/WASI/tree/wasi-0.1)
 which was based on WITX and is now deprecated.
 Preview 2 refers to [a newer iteration of the Component Model](https://github.com/WebAssembly/WASI/blob/main/docs/Preview2.md)
 which uses WebAssembly Interface Types (WIT).
+Preview 3 (WASI 0.3, released June 11, 2026) adds native async to the Component Model:
+`async func`, `stream<T>`, and `future<T>` are now Canonical ABI primitives, and the `wasi:io` package is removed.
+See [Async, Streams, and Futures](../design/async.md) for the conceptual underpinnings
+and [Migrating from WASI P2 to WASI P3](../design/migrating-to-p3.md) for what changes for an existing component.
 
 Many programming language toolchains may only support Preview 1 components natively,
 but this isn't a problem in practice as Preview 1 components can be *adapted* into Preview 2 components automatically.
 
 While somewhat confusing, a WASI Preview 1 "component" is in fact a *WebAssembly core module*.
 More precisely, a Preview 1 "component" is a WebAssembly core module with a well-defined set of imports and exports ([legacy specification][wasi-p1]).
+
+## Q: What is WASI P3?
+
+WASI P3 (WASI 0.3) is the latest milestone release of WASI, published on June 11, 2026.
+It rebases WASI's interfaces onto three new Canonical ABI primitives that the Component Model added for this release:
+[`async func`, `stream<T>`, and `future<T>`](../design/async.md).
+The `wasi:io` package is removed; its functionality is now provided by the Component Model directly.
+
+The practical effect is smaller, more composable WASI interfaces.
+The `wasi:http` handler is an `async func` returning a response;
+stdin, stdout, and stderr use `stream<u8>`;
+and async operations propagate readiness across component boundaries without each component running its own event loop.
+
+For a per-interface overview of what changed, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
+
+## Q: Do I need to migrate from WASI P2 to WASI P3?
+
+Not immediately.
+WASI P3 runtimes can polyfill P2 by mapping P2 imports onto native P3 primitives at the host boundary,
+and Wasmtime's `wasmtime serve` already runs both P3 and P2 components from the same binary, dispatching per component.
+
+Migrating is the right call when you want composable async across component boundaries
+or the newer interface shapes — in particular, `wasi:http`'s collapse of nine resources down to two.
+
+See [Migrating from WASI P2 to WASI P3](../design/migrating-to-p3.md) for the concept mapping
+and per-interface highlights.
+
+## Q: What happened to `wasi:io`?
+
+WASI P3 removes the `wasi:io` package entirely.
+The resources it provided (`pollable`, `input-stream`, and `output-stream`)
+are replaced by the Component Model's native Canonical ABI primitives
+`future<T>`, `stream<u8>`, and `stream<u8>` (used as a function parameter), respectively.
+
+The motivation was the so-called sandwich problem:
+when async readiness was expressed as a resource scoped to a single component,
+that readiness signal could not propagate cleanly across component boundaries.
+With native async in the Canonical ABI, the runtime owns scheduling and wake-up propagation.
+
+See [Async, Streams, and Futures](../design/async.md) for the underlying concepts.
 
 ## Q: What are component imports?
 

--- a/component-model/src/reference/faq.md
+++ b/component-model/src/reference/faq.md
@@ -86,7 +86,7 @@ which uses WebAssembly Interface Types (WIT).
 Preview 3 (WASI 0.3, released June 11, 2026) adds native async to the Component Model:
 `async func`, `stream<T>`, and `future<T>` are now Canonical ABI primitives, and the `wasi:io` package is removed.
 See [Async, Streams, and Futures](../design/async.md) for the conceptual underpinnings
-and [Migrating from WASI P2 to WASI P3](../design/migrating-to-p3.md) for what changes for an existing component.
+and [Migrating from WASI 0.2 to WASI 0.3](../design/migrating-to-p3.md) for what changes for an existing component.
 
 Many programming language toolchains may only support Preview 1 components natively,
 but this isn't a problem in practice as Preview 1 components can be *adapted* into Preview 2 components automatically.
@@ -94,9 +94,9 @@ but this isn't a problem in practice as Preview 1 components can be *adapted* in
 While somewhat confusing, a WASI Preview 1 "component" is in fact a *WebAssembly core module*.
 More precisely, a Preview 1 "component" is a WebAssembly core module with a well-defined set of imports and exports ([legacy specification][wasi-p1]).
 
-## Q: What is WASI P3?
+## Q: What is WASI 0.3?
 
-WASI P3 (WASI 0.3) is the latest milestone release of WASI, published on June 11, 2026.
+WASI 0.3 (WASI 0.3) is the latest milestone release of WASI, published on June 11, 2026.
 It rebases WASI's interfaces onto three new Canonical ABI primitives that the Component Model added for this release:
 [`async func`, `stream<T>`, and `future<T>`](../design/async.md).
 The `wasi:io` package is removed; its functionality is now provided by the Component Model directly.
@@ -106,23 +106,23 @@ The `wasi:http` handler is an `async func` returning a response;
 stdin, stdout, and stderr use `stream<u8>`;
 and async operations propagate readiness across component boundaries without each component running its own event loop.
 
-For a per-interface overview of what changed, see [WASI P3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
+For a per-interface overview of what changed, see [WASI 0.3](https://wasi.dev/releases/wasi-p3) on WASI.dev.
 
-## Q: Do I need to migrate from WASI P2 to WASI P3?
+## Q: Do I need to migrate from WASI 0.2 to WASI 0.3?
 
 Not immediately.
-WASI P3 runtimes can polyfill P2 by mapping P2 imports onto native P3 primitives at the host boundary,
-and Wasmtime's `wasmtime serve` already runs both P3 and P2 components from the same binary, dispatching per component.
+WASI 0.3 runtimes can polyfill 0.2 by mapping 0.2 imports onto native 0.3 primitives at the host boundary,
+and Wasmtime's `wasmtime serve` already runs both 0.3 and 0.2 components from the same binary, dispatching per component.
 
 Migrating is the right call when you want composable async across component boundaries
 or the newer interface shapes — in particular, `wasi:http`'s collapse of nine resources down to two.
 
-See [Migrating from WASI P2 to WASI P3](../design/migrating-to-p3.md) for the concept mapping
+See [Migrating from WASI 0.2 to WASI 0.3](../design/migrating-to-p3.md) for the concept mapping
 and per-interface highlights.
 
 ## Q: What happened to `wasi:io`?
 
-WASI P3 removes the `wasi:io` package entirely.
+WASI 0.3 removes the `wasi:io` package entirely.
 The resources it provided (`pollable`, `input-stream`, and `output-stream`)
 are replaced by the Component Model's native Canonical ABI primitives
 `future<T>`, `stream<u8>`, and `stream<u8>` (used as a function parameter), respectively.


### PR DESCRIPTION
Updates the existing "Preview 1 and Preview 2" question to cover Preview 3, and adds three new entries — "What is WASI P3?", "Do I need to migrate from WASI P2 to WASI P3?", and "What happened to `wasi:io`?" — that cross-link to the new `design/async.md` and `design/migrating-to-p3.md` pages added in #352, on which this PR is stacked.