### PR TITLE
chore: remove linkcheck hacks

### DIFF
--- a/component-model/src/design/component-model-concepts.md
+++ b/component-model/src/design/component-model-concepts.md
@@ -60,7 +60,7 @@ must be invoked in an environment that implements those interfaces.
 
  A [_package_](./packages.md) is a set of WIT files
 containing a related set of interfaces and worlds.
- 
+
 For example, the [wasi-http](https://github.com/WebAssembly/WASI/blob/main/proposals/http/wit/proxy.wit) package includes
 an `imports` world encapsulating the interfaces that an HTTP proxy depends on,
 and a `proxy` world that depends on `imports`.
@@ -106,5 +106,3 @@ standardizing the functionality components depend on.
 [wasi-cli-stdio]: https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/stdio.wit
 [wasi-cli-command]: https://github.com/WebAssembly/WASI/blob/main/proposals/cli/wit/command.wit
 [wasi-http]: https://github.com/WebAssembly/WASI/tree/main/proposals/http
-
-[!NOTE]: #

--- a/component-model/src/introduction.md
+++ b/component-model/src/introduction.md
@@ -93,5 +93,3 @@ The [WASI.dev roadmap](https://wasi.dev/roadmap) tracks upcoming releases.
 If you find a mistake, omission, ambiguity, or other problem, please let us know via [GitHub issues](https://github.com/bytecodealliance/component-docs/issues).
 
 If you'd like to contribute content to the guide, please see the [contribution guide](https://github.com/bytecodealliance/component-docs/blob/main/CONTRIBUTING.md) for information on how to contribute.
-
-[!NOTE]: #

--- a/component-model/src/language-support/building-a-simple-component/csharp.md
+++ b/component-model/src/language-support/building-a-simple-component/csharp.md
@@ -222,6 +222,3 @@ wasmtime run ./dist/main.wasm
 Check out the [componentize-dotnet docs][componentize-dotnet-docs] for more configuration options.
 
 [componentize-dotnet-docs]: https://github.com/bytecodealliance/componentize-dotnet
-
-[!NOTE]: #
-[!WARNING]: #

--- a/component-model/src/language-support/building-a-simple-component/go.md
+++ b/component-model/src/language-support/building-a-simple-component/go.md
@@ -324,6 +324,3 @@ A successful run should show the following output
 
 [example-host]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/example-host
 [rust]: https://www.rust-lang.org/learn/get-started
-
-[!NOTE]: #
-[!WARNING]: #

--- a/component-model/src/language-support/building-a-simple-component/javascript.md
+++ b/component-model/src/language-support/building-a-simple-component/javascript.md
@@ -293,7 +293,3 @@ With `jco transpile`, any WebAssembly binary (compiled from any language) can be
 [wasm-core-module]: https://webassembly.github.io/spec/core/binary/modules.html
 [core-wasm]: https://webassembly.github.io/spec/core/
 [ts-decl-file]: https://www.typescriptlang.org/docs/handbook/declaration-files/deep-dive.html#declaration-file-theory-a-deep-dive
-
-[!TIP]: #
-[!NOTE]: #
-[!WARNING]: #

--- a/component-model/src/language-support/building-a-simple-component/python.md
+++ b/component-model/src/language-support/building-a-simple-component/python.md
@@ -133,5 +133,3 @@ You can find another example of a Python host usage via `wasmtime-py` in the [co
 [add-wasm]: https://github.com/bytecodealliance/component-docs/blob/main/component-model/examples/example-host/add.wasm
 
 [adder-wit]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/tutorial/wit/adder/world.wit
-
-[!NOTE]: #

--- a/component-model/src/language-support/building-a-simple-component/rust.md
+++ b/component-model/src/language-support/building-a-simple-component/rust.md
@@ -251,5 +251,3 @@ With this, we have successfully built and run a basic WebAssembly component with
 [crates-wasmtime]: https://crates.io/crates/wasmtime
 [repo-component-docs]: https://github.com/bytecodealliance/component-docs
 [docs-adder]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/tutorial/wit/adder/world.wit
-[!NOTE]: #
-[!WARNING]: #

--- a/component-model/src/language-support/creating-runnable-components/rust.md
+++ b/component-model/src/language-support/creating-runnable-components/rust.md
@@ -133,8 +133,6 @@ or platforms can use the `greet` interface export. More importantly, the compone
 recognized as a generically runnable component thanks to `wasi:cli/run`, so it can work
 with any tooling (ex. `wasmtime run`) that supports/recognizes the `wasi:cli` interface.
 
-[!WARNING]: #
-
 ### 3. Write the code for the component
 
 The following code can be inserted into `runnable-example/src/lib.rs`:

--- a/component-model/src/language-support/importing-and-reusing-components/javascript.md
+++ b/component-model/src/language-support/importing-and-reusing-components/javascript.md
@@ -311,7 +311,3 @@ With the help of `jco`, we have:
 [string-reverse-package-json]: https://github.com/bytecodealliance/jco/blob/main/examples/components/string-reverse/package.json#L6
 [ts-decl-file]: https://www.typescriptlang.org/docs/handbook/declaration-files/deep-dive.html#declaration-file-theory-a-deep-dive
 [wasi]: https://wasi.dev/
-
-[!NOTE]: #
-[!TIP]: #
-[!WARNING]: #

--- a/component-model/src/language-support/importing-and-reusing-components/rust.md
+++ b/component-model/src/language-support/importing-and-reusing-components/rust.md
@@ -101,5 +101,3 @@ As the import is unfulfilled, the `calculator.wasm` component could not run by i
 
 The process of fulfilling imports via other component's exports is called "composition". Learn more about how to compose the calculator.wasm
 with an adder.wasm into a single, self-contained component in the [component composition guide](../../composing-and-distributing/composing.md).
-
-[!NOTE]: #

--- a/component-model/src/language-support/using-http-in-components/rust.md
+++ b/component-model/src/language-support/using-http-in-components/rust.md
@@ -121,6 +121,3 @@ Explore more examples of projects that use `wstd`:
 - [An example `wasi:http` server component](https://github.com/bytecodealliance/sample-wasi-http-rust)
 - [Various examples of using wstd](https://github.com/bytecodealliance/wstd/tree/main/examples)
 - [Examples of using wstd with Axum](https://github.com/bytecodealliance/wstd/tree/main/axum/examples)
-
-
-[!NOTE]: #

--- a/component-model/src/language-support/using-wit-resources/rust.md
+++ b/component-model/src/language-support/using-wit-resources/rust.md
@@ -233,6 +233,3 @@ to the Wasmtime runtime; other runtimes may express things differently.
     ```
 
 [docs-adder]: https://github.com/bytecodealliance/component-docs/tree/main/component-model/examples/tutorial/wit/adder/world.wit
-
-[!NOTE]: #
-[!WARNING]: #

--- a/component-model/src/reference/faq.md
+++ b/component-model/src/reference/faq.md
@@ -142,5 +142,3 @@ Please contribute to the Component Book by filing your question (or one that you
 as [an issue on GitHub][gh-issues-new].
 
 [gh-issues-new]: https://github.com/bytecodealliance/component-docs/issues/new
-
-[!NOTE]: #

--- a/component-model/src/tutorial.md
+++ b/component-model/src/tutorial.md
@@ -203,5 +203,3 @@ expanded enum.
 Another extension of this tutorial could be to remove the `op` enum and instead modify
 `eval-expression` to take in a string that can then be parsed to determine which operator component
 to call. Maybe this parser is a component of its own?!
-
-[!NOTE]: #


### PR DESCRIPTION
This commit removes the links that were added to avoid linkcheck's warnings about links that were missing (`[!NOTE]` would be interpreted as a non-working link).

With the update to mdbook and proper admonition support, these hacks are no longer necessary.

NOTE: this should merge after #346 