### PR TITLE
Add mdbook-tabs dependency

### DIFF
--- a/.github/actions/mdbook/action.yml
+++ b/.github/actions/mdbook/action.yml
@@ -39,6 +39,13 @@ inputs:
     description: |
       Version of mdbook-linkcheck to use (ex. '0.7.7')
 
+  mdbook-tabs-version:
+    type: string
+    required: false
+    default: "0.1.13"
+    description: |
+      Version of mdbook-tabs to use (ex. '0.1.13')
+
 runs:
   using: composite
   steps:
@@ -57,6 +64,10 @@ runs:
     - uses: taiki-e/cache-cargo-install-action@4d586f211d9b0bca9e7b59e57e2a0febf36c0929 # v2.1.1
       with:
         tool: "mdbook-linkcheck@${{ inputs.mdbook-linkcheck-version }}"
+
+    - uses: taiki-e/cache-cargo-install-action@4d586f211d9b0bca9e7b59e57e2a0febf36c0929 # v2.1.1
+      with:
+        tool: "mdbook-tabs@${{ inputs.mdbook-tabs-version }}"
 
     - name: Setup Python
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ This repository also makes use of mdBook plugins. To install mdBook and the plug
 cargo install --version 0.4.21 mdbook
 cargo install --version 0.6.7 mdbook-alerts
 cargo install --version 0.7.7 mdbook-linkcheck
+cargo install --version 0.1.13 mdbook-tabs
 ```
 
 [cargo]: https://doc.rust-lang.org/cargo


### PR DESCRIPTION
With the recent WASIP3 release, the https://component-model.bytecodealliance.org/running-components/wasmtime.html page was changed to include tabs for Wasip2/Wasip3. But the dependency (mdbook-tabs) was not added to neither the install instruction for contributors, nor to the github workflows. This PR adds it to both.

Without this PR:
<img width="1582" height="572" alt="image" src="https://github.com/user-attachments/assets/591f8e44-2c79-4b7b-90ab-7d7cd946b5e7" />

Local version, with the changes from this PR:
<img width="1582" height="572" alt="image" src="https://github.com/user-attachments/assets/86e513d9-7226-4683-a381-069e97380e0c" />


Version 0.1.13 of mdbook-tabs is the newest version not to clash with mdbook.0.4.21. Newer ones would require an update to mdbook itself.

